### PR TITLE
(fix): Added guard clause for fetchSchema() (Desktop)

### DIFF
--- a/src/adapter/desktop.tsx
+++ b/src/adapter/desktop.tsx
@@ -106,6 +106,10 @@ export class DesktopAdapter implements SurrealistAdapter {
 			return acc + `INFO FOR TABLE ${table.name};`;
 		}, '');
 
+		if (!tableQuery) {
+			return [];
+		}
+
 		const tableData = await surreal.query(tableQuery);
 
 		return map(databaseInfo, async (table, index) => {


### PR DESCRIPTION
Added guard clause for fetchSchema() (Desktop)

**RCA**: When the database has no tables `fetchSchema()` triggeres `surreal.query()` with an empty string as a method that throws an Exception that blocks refreshing and deleting tables from UI.

fixes #65