### PR TITLE
Replace ws -> http rather than http -> ws; Also replace wss; Only replace from start of string

### DIFF
--- a/src/adapter/desktop.tsx
+++ b/src/adapter/desktop.tsx
@@ -180,7 +180,7 @@ export class DesktopAdapter implements SurrealistAdapter {
 		const connection: any = mapKeys(options.connection, key => snake(key));
 		const details = {
 			...connection,
-			endpoint: connection.endpoint.replace("http", "ws")
+			endpoint: connection.endpoint.replace(/^ws/, "http")
 		};
 
 		invoke<any>('open_connection', { info: details }).then(() => {


### PR DESCRIPTION
The logic introduced in https://github.com/StarlaneStudios/Surrealist/commit/cfa4573770c93e28f90c344ca401103160076066 was supposed to be the other way around.

I replaced this logic with a regex, which will only replace "ws" from only the beginning of the endpoint with "http".