### PR TITLE
fix: database importing always showing success msg

### DIFF
--- a/src/components/App/modals/data-import.tsx
+++ b/src/components/App/modals/data-import.tsx
@@ -49,11 +49,12 @@ const SqlImportForm = ({ isImporting, confirmImport }: SqlImportFormProps) => {
 	const submit = () => {
 		const execute = async (content: string) => {
 			const result = await executeQuery(content);
+			const failed = result.some((result) => !result.success);
 
-			if (!result[0].success) {
+			if (failed) {
 				showError({
 					title: "Import failed",
-					subtitle: `There was an error importing the database: ${result[0].result}`,
+					subtitle: "There was an error importing the database",
 				});
 
 				return;


### PR DESCRIPTION
This PR fixes a bug where when importing a database from a file it would always show a success message even when it fails