### PR TITLE
Fix: Remove Access token from Localstorage after invalidation

### DIFF
--- a/src/cloud/api/auth.tsx
+++ b/src/cloud/api/auth.tsx
@@ -323,6 +323,7 @@ export function invalidateSession() {
 	adapter.log("Cloud", "Invalidating active session");
 
 	localStorage.removeItem(TOKEN_REFRESH_KEY);
+	localStorage.removeItem(TOKEN_ACCESS_KEY);
 
 	clearSession();
 


### PR DESCRIPTION
- After you log out with `account - a` and logged in after with `account - b`, the moment you refresh after a successful login with `account - b`, you will be authenticated with the access token of `account - a`. resulting in initializing the profile of `account - a` instead of `account - b`