### PR TITLE
Reverse order of import and export

### DIFF
--- a/src/screens/surrealist/components/ConnectionStatus/index.tsx
+++ b/src/screens/surrealist/components/ConnectionStatus/index.tsx
@@ -221,16 +221,16 @@ export function ConnectionStatus() {
 						<Menu.Item
 							leftSection={<Icon path={iconUpload} />}
 							disabled={currentState !== "connected"}
-							onClick={exportDatabase}
+							onClick={importDatabase}
 						>
-							Export database
+							Import database
 						</Menu.Item>
 						<Menu.Item
 							leftSection={<Icon path={iconDownload} />}
 							disabled={currentState !== "connected"}
-							onClick={importDatabase}
+							onClick={exportDatabase}
 						>
-							Import database
+							Export database
 						</Menu.Item>
 						<Menu.Label mt="sm">Manage</Menu.Label>
 						{!isManaged && (

--- a/src/screens/surrealist/views/explorer/ExplorerView/index.tsx
+++ b/src/screens/surrealist/views/explorer/ExplorerView/index.tsx
@@ -140,20 +140,20 @@ export function ExplorerView() {
 											<Entry
 												leftSection={<Icon path={iconUpload} />}
 												rightSection={<Icon path={iconChevronRight} />}
-												onClick={exportDatabase}
-												style={{ flexShrink: 0 }}
-												bg="transparent"
-											>
-												Export database
-											</Entry>
-											<Entry
-												leftSection={<Icon path={iconDownload} />}
-												rightSection={<Icon path={iconChevronRight} />}
 												onClick={importDatabase}
 												style={{ flexShrink: 0 }}
 												bg="transparent"
 											>
 												Import database
+											</Entry>
+											<Entry
+												leftSection={<Icon path={iconDownload} />}
+												rightSection={<Icon path={iconChevronRight} />}
+												onClick={exportDatabase}
+												style={{ flexShrink: 0 }}
+												bg="transparent"
+											>
+												Export database
 											</Entry>
 										</>
 									}


### PR DESCRIPTION
This change reverses the order of the import and export buttons so that it makes more sense semantically and matches other import and export buttons across Surrealist.