### PR TITLE
Fix: Patch optional record links in designer

### DIFF
--- a/src/util/surrealql.tsx
+++ b/src/util/surrealql.tsx
@@ -129,6 +129,10 @@ function parseKindTree(obj: any, records: Set<string>) {
 		for (const record of obj.Record) {
 			records.add(record);
 		}
+	} else if (obj.Option.Record) {
+		for (const record of obj.Option.Record) {
+			records.add(record);
+		}
 	} else if (obj.Array) {
 		parseKindTree(obj.Array[0], records);
 	} else if (obj.Set) {


### PR DESCRIPTION
Closes #903 - Bug: Table graph does not show relations for optional types

#### Before
<img width="2944" height="1972" alt="image" src="https://github.com/user-attachments/assets/0fb6dbe0-81d3-48ed-a844-63de78544694" />

#### After
<img width="2944" height="1972" alt="image" src="https://github.com/user-attachments/assets/de5a066c-c337-4200-8d38-1a4527a717d0" />
