### PR TITLE
Change wasm functions to be async.

### DIFF
--- a/src/components/App/modals/highlight-tool.tsx
+++ b/src/components/App/modals/highlight-tool.tsx
@@ -62,8 +62,8 @@ export function HighlightToolModal() {
 		}));
 	}, []);
 
-	const format = useCallback(() => {
-		onChange(formatQuery(value));
+	const format = useCallback(async () => {
+		onChange(await formatQuery(value));
 	}, [value]);
 
 	useEffect(() => {

--- a/src/components/DataTable/datatypes.tsx
+++ b/src/components/DataTable/datatypes.tsx
@@ -1,6 +1,7 @@
 import { Group, HoverCard, Stack, Text } from "@mantine/core";
 import dayjs from "dayjs";
 import { convert } from "geo-coordinates-parser";
+import { useEffect, useState } from "react";
 import {
 	Decimal,
 	Duration,
@@ -166,6 +167,25 @@ function ArrayCell(props: { value: any[] }) {
 }
 
 function ObjectCell(props: { value: any }) {
+	const [formatted, setFormatted] = useState("");
+
+	useEffect(() => {
+		let cancelled = false;
+
+		const format = async () => {
+			const result = await formatValue(props.value, false, true);
+			if (!cancelled) {
+				setFormatted(result);
+			}
+		};
+
+		format();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [props.value]);
+
 	return (
 		<div>
 			<HoverCard
@@ -190,7 +210,7 @@ function ObjectCell(props: { value: any }) {
 						lineClamp={10}
 						className={classes.sourceCode}
 					>
-						{formatValue(props.value, false, true)}
+						{formatted}
 					</Text>
 				</HoverCard.Dropdown>
 			</HoverCard>

--- a/src/components/GeographyMap/index.tsx
+++ b/src/components/GeographyMap/index.tsx
@@ -60,19 +60,33 @@ export const GeographyMap = ({ value }: GeographyMapProps) => {
 	const [bounds, setBounds] = useState<any>();
 
 	useEffect(() => {
-		try {
-			const data = parseValue(value).toJSON();
+		let cancelled = false;
 
-			const leafletGeoJson = createGeoJSON(data, {
-				coordsToLatLng: convertCoordsToLatLng,
-			});
+		const loadData = async () => {
+			try {
+				const data = (await parseValue(value)).toJSON();
 
-			setIsError(false);
-			setData(leafletGeoJson.toGeoJSON());
-			setBounds(leafletGeoJson.getBounds());
-		} catch {
-			setIsError(true);
-		}
+				if (cancelled) return;
+
+				const leafletGeoJson = createGeoJSON(data, {
+					coordsToLatLng: convertCoordsToLatLng,
+				});
+
+				setIsError(false);
+				setData(leafletGeoJson.toGeoJSON());
+				setBounds(leafletGeoJson.getBounds());
+			} catch {
+				if (!cancelled) {
+					setIsError(true);
+				}
+			}
+		};
+
+		loadData();
+
+		return () => {
+			cancelled = true;
+		};
 	}, [value]);
 
 	useEffect(() => {

--- a/src/components/RecordLink/index.tsx
+++ b/src/components/RecordLink/index.tsx
@@ -1,5 +1,6 @@
 import { type BoxProps, type ElementProps, Group, Text } from "@mantine/core";
 import type { MouseEvent } from "react";
+import { useEffect, useState } from "react";
 import type { RecordId } from "surrealdb";
 import { useStable } from "~/hooks/stable";
 import { useInspector } from "~/providers/Inspector";
@@ -14,7 +15,24 @@ export interface RecordLinkProps extends BoxProps, ElementProps<"div"> {
 
 export function RecordLink({ value, withOpen, ...rest }: RecordLinkProps) {
 	const { inspect } = useInspector();
-	const recordText = formatValue(value);
+	const [recordText, setRecordText] = useState("");
+
+	useEffect(() => {
+		let cancelled = false;
+
+		const format = async () => {
+			const result = await formatValue(value);
+			if (!cancelled) {
+				setRecordText(result);
+			}
+		};
+
+		format();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [value]);
 
 	const handleOpen = useStable((e: MouseEvent) => {
 		e.stopPropagation();

--- a/src/editor/surrealql.tsx
+++ b/src/editor/surrealql.tsx
@@ -53,7 +53,7 @@ export const getQueryRange = (view: EditorView, head?: number): [number, number]
  */
 export const surqlLinting = (onValidate?: (status: string) => void): Extension =>
 	linter(
-		(view) => {
+		async (view) => {
 			const isEnabled = getSetting("behavior", "queryErrorChecker");
 			const content = view.state.doc.toString();
 
@@ -61,7 +61,7 @@ export const surqlLinting = (onValidate?: (status: string) => void): Extension =
 				return [];
 			}
 
-			const message = validateQuery(content) || "";
+			const message = (await validateQuery(content)) || "";
 			const match = message.match(/^Parse error: (.+)?\s+-->\s+\[(\d+):(\d+)\]/i);
 
 			if (match) {

--- a/src/hooks/surrealql.ts
+++ b/src/hooks/surrealql.ts
@@ -1,11 +1,11 @@
 import { useDebouncedValue } from "@mantine/hooks";
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 import type { ResultFormat } from "~/types";
 import { formatValue, parseValue } from "~/util/surrealql";
 import { useActiveQuery } from "./connection";
 import { useStable } from "./stable";
 
-export type Formatter = (value: any) => string;
+export type Formatter = (value: any) => Promise<string>;
 
 /**
  * A hook used to format SurrealQL structures into strings
@@ -14,8 +14,8 @@ export function useResultFormatter(): [Formatter, ResultFormat] {
 	const query = useActiveQuery();
 	const format = query?.resultFormat || "sql";
 
-	const formatter = useStable((value: any) => {
-		return formatValue(value, format === "json", true);
+	const formatter = useStable(async (value: any) => {
+		return await formatValue(value, format === "json", true);
 	});
 
 	return [formatter, format];
@@ -27,20 +27,45 @@ export function useResultFormatter(): [Formatter, ResultFormat] {
  * @param value The value to check
  * @param objectRoot Whether the value should be an object
  */
-export function useValueValidator(value: string, objectRoot?: boolean): [boolean, any] {
+export function useValueValidator(value: string, objectRoot?: boolean): [boolean, any, boolean] {
 	const [bodyCache] = useDebouncedValue(value, 250);
+	const [isValid, setIsValid] = useState(false);
+	const [parsedValue, setParsedValue] = useState<any>({});
+	const [isLoading, setIsLoading] = useState(false);
 
-	return useMemo(() => {
-		try {
-			const value = parseValue(bodyCache);
+	useEffect(() => {
+		let cancelled = false;
 
-			if (objectRoot && typeof value !== "object" && !Array.isArray(value)) {
-				throw new Error("Invalid object root");
+		const validate = async () => {
+			setIsLoading(true);
+			try {
+				const value = await parseValue(bodyCache);
+
+				if (cancelled) return;
+
+				if (objectRoot && typeof value !== "object" && !Array.isArray(value)) {
+					throw new Error("Invalid object root");
+				}
+
+				setIsValid(true);
+				setParsedValue(value);
+			} catch {
+				if (cancelled) return;
+				setIsValid(false);
+				setParsedValue({});
+			} finally {
+				if (!cancelled) {
+					setIsLoading(false);
+				}
 			}
+		};
 
-			return [true, value];
-		} catch {
-			return [false, {}];
-		}
+		validate();
+
+		return () => {
+			cancelled = true;
+		};
 	}, [bodyCache, objectRoot]);
+
+	return [isValid, parsedValue, isLoading];
 }

--- a/src/providers/Inspector/drawer.tsx
+++ b/src/providers/Inspector/drawer.tsx
@@ -105,10 +105,10 @@ export function InspectorDrawer({ opened, history, onClose, onRefresh }: Inspect
 			{ id },
 		);
 
-		const formatted = formatValue(content, false, true);
+		const formatted = await formatValue(content, false, true);
 
 		setError("");
-		setRecordId(formatValue(id));
+		setRecordId(await formatValue(id));
 		setCurrentRecord({
 			isEdge: !!content?.in && !!content?.out,
 			exists: !!content,
@@ -130,8 +130,8 @@ export function InspectorDrawer({ opened, history, onClose, onRefresh }: Inspect
 		}
 	});
 
-	const gotoRecord = useStable(() => {
-		const id = parseValue(recordId);
+	const gotoRecord = useStable(async () => {
+		const id = await parseValue(recordId);
 
 		if (id instanceof RecordId) {
 			history.push(id);
@@ -143,7 +143,7 @@ export function InspectorDrawer({ opened, history, onClose, onRefresh }: Inspect
 		confirmText: "Delete",
 		skippable: true,
 		onConfirm: async () => {
-			await executeQuery(/* surql */ `DELETE ${formatValue(history.current)}`);
+			await executeQuery(/* surql */ `DELETE ${await formatValue(history.current)}`);
 
 			history.clear();
 

--- a/src/providers/Inspector/index.tsx
+++ b/src/providers/Inspector/index.tsx
@@ -8,7 +8,7 @@ import { RecordsChangedEvent } from "~/util/global-events";
 import { parseValue } from "~/util/surrealql";
 import { InspectorDrawer } from "./drawer";
 
-type InspectFunction = (record: RecordId | string) => void;
+type InspectFunction = (record: RecordId | string) => Promise<void>;
 type StopInspectFunction = () => void;
 
 const InspectorContext = createContext<{
@@ -26,7 +26,7 @@ export function useInspector() {
 	return (
 		ctx ?? {
 			history: [],
-			inspect: () => {},
+			inspect: async () => {},
 			stopInspect: () => {},
 		}
 	);
@@ -41,9 +41,11 @@ export function InspectorProvider({ children }: PropsWithChildren) {
 		setHistory: setHistoryItems,
 	});
 
-	const inspect = useStable((record: RecordId | string) => {
+	const inspect = useStable(async (record: RecordId | string) => {
 		const recordId =
-			typeof record === "string" ? parseValue(record) : new RecordId(record.tb, record.id);
+			typeof record === "string"
+				? await parseValue(record)
+				: new RecordId(record.tb, record.id);
 
 		if (!(recordId instanceof RecordId)) {
 			throw new TypeError("Invalid record id");

--- a/src/screens/surrealist/connection/connection.tsx
+++ b/src/screens/surrealist/connection/connection.tsx
@@ -414,7 +414,7 @@ export async function executeUserQuery(options?: UserQueryOptions) {
 		let liveIndexes: number[];
 
 		try {
-			liveIndexes = getLiveQueries(query);
+			liveIndexes = await getLiveQueries(query);
 		} catch (err: any) {
 			adapter.warn("DB", `Failed to parse live queries: ${err.message}`);
 			console.error(err);

--- a/src/screens/surrealist/pages/OrganizationManage/tabs/invoices.tsx
+++ b/src/screens/surrealist/pages/OrganizationManage/tabs/invoices.tsx
@@ -1,5 +1,4 @@
 import { ActionIcon, Alert, Paper, Skeleton, Stack, Table } from "@mantine/core";
-import { Link } from "wouter";
 import { adapter } from "~/adapter";
 import { useCloudInvoicesQuery } from "~/cloud/queries/invoices";
 import { Icon } from "~/components/Icon";

--- a/src/screens/surrealist/pages/Support/RequestsPage/index.tsx
+++ b/src/screens/surrealist/pages/Support/RequestsPage/index.tsx
@@ -11,7 +11,7 @@ import { usePagination } from "~/components/Pagination/hook";
 import { PrimaryTitle } from "~/components/PrimaryTitle";
 import { Spacer } from "~/components/Spacer";
 import { SUPPORT_REQUEST_TYPES } from "~/constants";
-import { iconArrowLeft, iconPlus } from "~/util/icons";
+import { iconPlus } from "~/util/icons";
 import { dispatchIntent } from "~/util/intents";
 import { ConversationCard } from "../ConversationCard";
 import classes from "../style.module.scss";

--- a/src/screens/surrealist/views/authentication/LevelPanel/models/access.tsx
+++ b/src/screens/surrealist/views/authentication/LevelPanel/models/access.tsx
@@ -124,11 +124,11 @@ export function AccessEditorModal({ level, existing, opened, onClose }: AccessEd
 				query += ` RECORD`;
 
 				if (signupClause) {
-					query += ` SIGNUP ${writeBlock(signupClause)}`;
+					query += ` SIGNUP ${await writeBlock(signupClause)}`;
 				}
 
 				if (signinClause) {
-					query += ` SIGNIN ${writeBlock(signinClause)}`;
+					query += ` SIGNIN ${await writeBlock(signinClause)}`;
 				}
 
 				if (jwtIssuerKey || jwtVerifyKey || jwtVerifyUrl) {
@@ -155,7 +155,7 @@ export function AccessEditorModal({ level, existing, opened, onClose }: AccessEd
 			}
 
 			if (authClause) {
-				query += ` AUTHENTICATE ${writeBlock(authClause)}`;
+				query += ` AUTHENTICATE ${await writeBlock(authClause)}`;
 			}
 
 			const durations: string[] = [];

--- a/src/screens/surrealist/views/designer/TableGraphPane/helpers.tsx
+++ b/src/screens/surrealist/views/designer/TableGraphPane/helpers.tsx
@@ -81,13 +81,13 @@ function normalizeTables(tables: TableInfo[]): NormalizedTable[] {
 	});
 }
 
-export function buildFlowNodes(
+export async function buildFlowNodes(
 	tables: TableInfo[],
 	nodeMode: DiagramMode,
 	direction: DiagramDirection,
 	linkMode: DiagramLinks,
 	lineStyle: DiagramLineStyle,
-): [Node[], Edge[], GraphWarning[]] {
+): Promise<[Node[], Edge[], GraphWarning[]]> {
 	const items = normalizeTables(tables);
 	const nodeIndex: Record<string, Node> = {};
 	const edges: Edge[] = [];
@@ -215,7 +215,7 @@ export function buildFlowNodes(
 					continue;
 				}
 
-				const targets = extractKindRecords(field.kind);
+				const targets = await extractKindRecords(field.kind);
 
 				for (const target of targets) {
 					if (

--- a/src/screens/surrealist/views/designer/TableGraphPane/index.tsx
+++ b/src/screens/surrealist/views/designer/TableGraphPane/index.tsx
@@ -177,7 +177,7 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 	}, [nodesInitialized, algorithm, direction]);
 
 	const renderGraph = useStable(async () => {
-		const [nodes, edges, warnings] = buildFlowNodes(
+		const [nodes, edges, warnings] = await buildFlowNodes(
 			props.tables,
 			nodeMode,
 			direction,

--- a/src/screens/surrealist/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
+++ b/src/screens/surrealist/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
@@ -1,6 +1,6 @@
 import { Box, Divider, Flex, Group, Paper, ScrollArea, Stack, Text, Tooltip } from "@mantine/core";
 import { Handle, Position } from "@xyflow/react";
-import { type MouseEvent, type ReactNode, useRef } from "react";
+import { type MouseEvent, type ReactNode, useEffect, useRef, useState } from "react";
 import { Icon } from "~/components/Icon";
 import { Spacer } from "~/components/Spacer";
 import { TABLE_VARIANT_ICONS } from "~/constants";
@@ -191,6 +191,34 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 	const inField = table.fields.find((f) => f.name === "in");
 	const outField = table.fields.find((f) => f.name === "out");
 
+	const [inRecords, setInRecords] = useState<string>("");
+	const [outRecords, setOutRecords] = useState<string>("");
+
+	useEffect(() => {
+		let cancelled = false;
+
+		const loadRecords = async () => {
+			if (inField) {
+				const records = await extractKindRecords(inField.kind ?? "");
+				if (!cancelled) {
+					setInRecords(records.join(", "));
+				}
+			}
+			if (outField) {
+				const records = await extractKindRecords(outField.kind ?? "");
+				if (!cancelled) {
+					setOutRecords(records.join(", "));
+				}
+			}
+		};
+
+		loadRecords();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [inField, outField]);
+
 	return (
 		<>
 			<Handle
@@ -253,20 +281,12 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 							<Field
 								isLight={isLight}
 								name="in"
-								value={
-									<Text ta="right">
-										{extractKindRecords(inField.kind ?? "").join(", ")}
-									</Text>
-								}
+								value={<Text ta="right">{inRecords}</Text>}
 							/>
 							<Field
 								isLight={isLight}
 								name="out"
-								value={
-									<Text ta="right">
-										{extractKindRecords(outField.kind ?? "").join(", ")}
-									</Text>
-								}
+								value={<Text ta="right">{outRecords}</Text>}
 							/>
 						</Stack>
 					</>

--- a/src/screens/surrealist/views/explorer/CreatorDrawer/index.tsx
+++ b/src/screens/surrealist/views/explorer/CreatorDrawer/index.tsx
@@ -115,16 +115,20 @@ export function CreatorDrawer({ opened, table, content, onClose }: CreatorDrawer
 
 	useLayoutEffect(() => {
 		if (opened) {
-			const bodyText = content
-				? formatValue(omit(content, ["id", "in", "out"]), true, true)
-				: "{\n    \n}";
+			const initializeBody = async () => {
+				const bodyText = content
+					? await formatValue(omit(content, ["id", "in", "out"]), true, true)
+					: "{\n    \n}";
 
-			setErrors([]);
-			setRecordTable(table);
-			setRecordId("");
-			setRecordBody(bodyText);
-			setRecordFrom("");
-			setRecordTo("");
+				setErrors([]);
+				setRecordTable(table);
+				setRecordId("");
+				setRecordBody(bodyText);
+				setRecordFrom("");
+				setRecordTo("");
+			};
+
+			initializeBody();
 		}
 	}, [opened, table, content]);
 

--- a/src/screens/surrealist/views/functions/FunctionEditorPanel/index.tsx
+++ b/src/screens/surrealist/views/functions/FunctionEditorPanel/index.tsx
@@ -48,8 +48,8 @@ export function FunctionEditorPanel({
 		);
 	});
 
-	const formatFunction = useStable(() => {
-		const isFunctionBlockInvalid = validateQuery(details.block);
+	const formatFunction = useStable(async () => {
+		const isFunctionBlockInvalid = await validateQuery(details.block);
 		if (isFunctionBlockInvalid) {
 			showErrorNotification({
 				title: "Failed to format",
@@ -57,7 +57,7 @@ export function FunctionEditorPanel({
 			});
 			return;
 		}
-		const formattedFunctionBlock = formatQuery(details.block);
+		const formattedFunctionBlock = await formatQuery(details.block);
 		onChange((draft) => {
 			(draft.details as SchemaFunction).block = formattedFunctionBlock;
 		});

--- a/src/screens/surrealist/views/functions/FunctionsView/index.tsx
+++ b/src/screens/surrealist/views/functions/FunctionsView/index.tsx
@@ -136,7 +136,7 @@ export function FunctionsView() {
 		setCreateName("");
 	});
 
-	const editFunction = useStable((func: FunctionDetails) => {
+	const editFunction = useStable(async (func: FunctionDetails) => {
 		isCreatingHandle.close();
 
 		if (func.type === "model") {
@@ -146,8 +146,8 @@ export function FunctionsView() {
 			});
 		} else {
 			const f = func.details as SchemaFunction;
-			const isInvalid = validateQuery(f.block);
-			const block = isInvalid ? f.block : formatQuery(f.block);
+			const isInvalid = await validateQuery(f.block);
+			const block = isInvalid ? f.block : await formatQuery(f.block);
 
 			setActive({
 				type: "function",

--- a/src/screens/surrealist/views/graphql/QueryPane/index.tsx
+++ b/src/screens/surrealist/views/graphql/QueryPane/index.tsx
@@ -100,7 +100,7 @@ export function QueryPane({
 		setShowVariables(!showVariables);
 	});
 
-	const inferVariables = useStable(() => {
+	const inferVariables = useStable(async () => {
 		if (!connection) return;
 
 		try {
@@ -137,7 +137,7 @@ export function QueryPane({
 			setShowVariables(true);
 			updateConnection({
 				id: connection,
-				graphqlVariables: formatValue(mergedVars, false, true),
+				graphqlVariables: await formatValue(mergedVars, false, true),
 			});
 		} catch {
 			showErrorNotification({

--- a/src/screens/surrealist/views/query/QueryPane/index.tsx
+++ b/src/screens/surrealist/views/query/QueryPane/index.tsx
@@ -139,16 +139,16 @@ export function QueryPane({
 		});
 	});
 
-	const handleFormat = useStable(() => {
+	const handleFormat = useStable(async () => {
 		if (!editor) return;
 
 		try {
 			const document = editor.state.doc;
 			const formatted = hasSelection
 				? document.sliceString(0, selection.from) +
-					formatQuery(document.sliceString(selection.from, selection.to)) +
+					(await formatQuery(document.sliceString(selection.from, selection.to))) +
 					document.sliceString(selection.to)
-				: formatQuery(document.toString());
+				: await formatQuery(document.toString());
 
 			setEditorText(editor, formatted);
 		} catch {
@@ -163,7 +163,7 @@ export function QueryPane({
 		setShowVariables(!showVariables);
 	});
 
-	const inferVariables = useStable(() => {
+	const inferVariables = useStable(async () => {
 		if (!activeTab || !connection) return;
 
 		const tree = syntaxTree(editor.state);
@@ -184,7 +184,7 @@ export function QueryPane({
 		setShowVariables(true);
 		updateQueryTab(connection, {
 			id: activeTab.id,
-			variables: formatValue(mergedVars, false, true),
+			variables: await formatValue(mergedVars, false, true),
 		});
 	});
 

--- a/src/screens/surrealist/views/query/ResultPane/previews/index.tsx
+++ b/src/screens/surrealist/views/query/ResultPane/previews/index.tsx
@@ -9,8 +9,8 @@ export interface PreviewProps {
 	isLive: boolean;
 }
 
-export function attemptFormat(format: Formatter, data: any) {
-	const [err, res] = tryit(format)(data);
+export async function attemptFormat(format: Formatter, data: any): Promise<string> {
+	const [err, res] = await tryit(format)(data);
 
 	return err ? `"Error: ${err.message}"` : res;
 }

--- a/src/screens/surrealist/views/query/ResultPane/previews/individual.tsx
+++ b/src/screens/surrealist/views/query/ResultPane/previews/individual.tsx
@@ -1,6 +1,6 @@
 import { Text } from "@mantine/core";
 import { surrealql } from "@surrealdb/codemirror";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { CodeEditor } from "~/components/CodeEditor";
 import { surqlRecordLinks } from "~/editor";
 import { useSetting } from "~/hooks/config";
@@ -13,9 +13,27 @@ export function IndividualPreview({ responses, selected }: PreviewProps) {
 	const { inspect } = useInspector();
 	const { success, result } = responses[selected] ?? { result: null };
 	const [editorScale] = useSetting("appearance", "editorScale");
+	const [contents, setContents] = useState("");
 
 	const textSize = Math.floor(15 * (editorScale / 100));
-	const contents = useMemo(() => attemptFormat(format, result), [result, format]);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		const formatResult = async () => {
+			const formatted = await attemptFormat(format, result);
+			if (!cancelled) {
+				setContents(formatted);
+			}
+		};
+
+		formatResult();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [result, format]);
+
 	const extensions = useMemo(() => [surrealql(), surqlRecordLinks(inspect)], [inspect]);
 
 	return success ? (

--- a/src/util/schema.tsx
+++ b/src/util/schema.tsx
@@ -294,8 +294,9 @@ export function readBlock(block: string | undefined) {
 /**
  * Wrap a block in braces or parenthesis
  */
-export function writeBlock(block: string) {
-	const [openSymbol, closeSymbol] = getStatementCount(block) > 1 ? ["{", "}"] : ["(", ")"];
+export async function writeBlock(block: string): Promise<string> {
+	const [openSymbol, closeSymbol] =
+		(await getStatementCount(block)) > 1 ? ["{", "}"] : ["(", ")"];
 
 	return `${openSymbol}\n${block}\n${closeSymbol}`;
 }

--- a/src/util/surrealql.tsx
+++ b/src/util/surrealql.tsx
@@ -7,7 +7,7 @@ import { DatasetType } from "~/types";
 /**
  * Validate a query and return an error message if invalid
  */
-export function validateQuery(sql: string): string | undefined {
+export async function validateQuery(sql: string): Promise<string | undefined> {
 	try {
 		SurrealQL.validate(sql);
 		return undefined;
@@ -19,7 +19,7 @@ export function validateQuery(sql: string): string | undefined {
 /**
  * Validate a record id and return an error message if invalid
  */
-export function validateThing(thing: string): string | undefined {
+export async function validateThing(thing: string): Promise<string | undefined> {
 	try {
 		SurrealQL.validate_thing(thing);
 		return undefined;
@@ -31,7 +31,7 @@ export function validateThing(thing: string): string | undefined {
 /**
  * Validate a where clause and return an error message if invalid
  */
-export function validateWhere(where: string): string | undefined {
+export async function validateWhere(where: string): Promise<string | undefined> {
 	try {
 		(window as any).SurrealQL = SurrealQL;
 		SurrealQL.validate_where(where);
@@ -44,7 +44,7 @@ export function validateWhere(where: string): string | undefined {
 /**
  * Returns the amount of statements in a query
  */
-export function getStatementCount(sql: string): number {
+export async function getStatementCount(sql: string): Promise<number> {
 	return SurrealQL.parse(sql).length;
 }
 
@@ -56,7 +56,7 @@ export function getStatementCount(sql: string): number {
  * @param pretty Optionally pretty print
  * @returns The formatted value
  */
-export function formatValue(value: any, json = false, pretty = false) {
+export async function formatValue(value: any, json = false, pretty = false): Promise<string> {
 	const binary = new Uint8Array(encodeCbor(value));
 	const parsed = Value.from_cbor(binary);
 
@@ -69,7 +69,7 @@ export function formatValue(value: any, json = false, pretty = false) {
  * @param value The value string
  * @returns The parsed value structure
  */
-export function parseValue(value: string) {
+export async function parseValue(value: string): Promise<any> {
 	return decodeCbor(Value.from_string(value).to_cbor().buffer);
 }
 
@@ -79,7 +79,7 @@ export function parseValue(value: string) {
  * @param query The query to parse
  * @returns The indexes of the live query statements
  */
-export function getLiveQueries(query: string): number[] {
+export async function getLiveQueries(query: string): Promise<number[]> {
 	const tree: any[] = SurrealQL.parse(query);
 
 	return tree.reduce((acc: number[], stmt, idx) => {
@@ -97,7 +97,7 @@ export function getLiveQueries(query: string): number[] {
  * @param query Query string
  * @returns Formatted query
  */
-export function formatQuery(query: string, pretty = true) {
+export async function formatQuery(query: string, pretty = true): Promise<string> {
 	return SurrealQL.format(query, pretty);
 }
 
@@ -107,7 +107,7 @@ export function formatQuery(query: string, pretty = true) {
  * @param kind The kind to extract records from
  * @returns The extracted records
  */
-export function extractKindRecords(kind: string) {
+export async function extractKindRecords(kind: string): Promise<string[]> {
 	try {
 		const ast = SurrealQL.parse(`DEFINE FIELD dummy ON dummy TYPE ${kind}`);
 		const root = ast[0].Define.Field.kind;


### PR DESCRIPTION
Motivation:
In order to support using an LSP, we will necessarily need to move away from sync code over to async code in Surrealist. 

This change wraps the calls to all of the wasm functions in `async` functions and propagates all of the necessary async/awaits up the call stack.

Also fixed all of the `bun qc` issues.