### PR TITLE
Fix issue with cloud_created_event missing email info.

### DIFF
--- a/src/cloud/mutations/deploy.tsx
+++ b/src/cloud/mutations/deploy.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCloudStore } from "~/stores/cloud";
 import { CloudDeployConfig, CloudInstance, CloudOrganization } from "~/types";
 import { tagEvent } from "~/util/analytics";
 import { resolveInstanceConnection } from "~/util/connection";
@@ -38,6 +39,7 @@ export function useInstanceDeployMutation(
 				storage_size: instance.storage_size,
 				organisation: organisation.id,
 				dataset: config.startingData.datasetOptions?.id ?? "none",
+				email: useCloudStore.getState().profile.username,
 			});
 
 			return [instance, connection] as const;

--- a/src/util/analytics.tsx
+++ b/src/util/analytics.tsx
@@ -98,8 +98,8 @@ export async function tagEvent(name: string, payload: Record<string, unknown> = 
 		params.append("ep.aid", userId);
 	}
 
-	if (name === "cloud_signin" || name === "cloud_signout") {
-		params.append("ep.email", profile.username);
+	if (name === "cloud_signin" || name === "cloud_signout" || name === "cloud_instance_created") {
+		params.append("ep.email", (payload.email as string) || profile.username);
 	}
 
 	params.append("ep.utk", _ga);


### PR DESCRIPTION
Motivation:
Meriel reported that some of the created events are missing emails but it's pretty rare.

Underlying issue (afaict - I haven't tested this yet):
If a user creates an instance *before the profile API call completes*, the `profile` object in the store is still `EMPTY_PROFILE` with an empty `username`. The `userId` is set correctly (since it's set synchronously), but the email (from `profile.username`) is empty.

