### PR TITLE
Omit default ordering method

### DIFF
--- a/src/screens/surrealist/views/explorer/ExplorerPane/hooks.tsx
+++ b/src/screens/surrealist/views/explorer/ExplorerPane/hooks.tsx
@@ -41,10 +41,13 @@ export function useRecordQuery(input: RecordQueryInput) {
 				if (sortMode) {
 					const [sortField, sortDir] = sortMode;
 
-					fetchQuery += ` ORDER BY ${sortField} ${sortDir}`;
+					// Sorting defaults to id ascending
+					if (sortField !== "id" && sortDir !== "asc") {
+						fetchQuery += ` ORDER BY ${sortField} ${sortDir}`;
 
-					if (sortField !== "id") {
-						fetchQuery += `, id ${sortDir}`;
+						if (sortField !== "id") {
+							fetchQuery += `, id ${sortDir}`;
+						}
 					}
 				}
 


### PR DESCRIPTION
Avoid inserting an explicit `ORDER BY` for default sorting to optimise query execution