### PR TITLE
Fix empty responses

### DIFF
--- a/src/screens/surrealist/connection/connection.tsx
+++ b/src/screens/surrealist/connection/connection.tsx
@@ -330,7 +330,7 @@ export async function executeQuery(
 			} else if (frame.isDone()) {
 				const result = queryResponses.has(frame.query)
 					? queryResponses.get(frame.query)
-					: undefined;
+					: [];
 
 				results.push({
 					success: true,


### PR DESCRIPTION
Empty responses currently show up as `NONE` while it is safe to treat them as `[]`