### PR TITLE
Add styles to show table state more clearly in designer view

### DIFF
--- a/src/screens/surrealist/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
+++ b/src/screens/surrealist/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
@@ -219,6 +219,8 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 		};
 	}, [inField, outField]);
 
+	console.log(table.schema)
+
 	return (
 		<>
 			<Handle
@@ -241,11 +243,18 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 				p="md"
 				w={250}
 				title={`Click to edit ${table.schema.name}`}
-				bg={isLight ? "white" : "slate.7"}
+				bg={
+					table.schema.drop
+						? `linear-gradient(-45deg, var(--diagonal-color-2) 12.5%, var(--diagonal-color-1) 12.5%, var(--diagonal-color-1) 50%, var(--diagonal-color-2) 50%, var(--diagonal-color-2) 62.5%, var(--diagonal-color-1) 62.5%, var(--diagonal-color-1) 100%) center / 8px 8px`
+						: isLight ? "white" : "slate.7"
+				}
 				shadow={`0 8px 12px rgba(0, 0, 0, ${isLight ? 0.075 : 0.2})`}
 				style={{
-					border: `1px solid ${themeColor(isSelected ? "surreal" : isLight ? "slate.2" : "slate.5")}`,
+					'--diagonal-color-1': `var(${isLight ? 'white' : '--mantine-color-slate-7'})`,
+					'--diagonal-color-2': `var(${isLight ? '--mantine-color-slate-1' : '--mantine-color-slate-6'})`,
+					border: `${table.schema.full ? "2px solid" : "2px dashed"} ${themeColor(isSelected ? "surreal" : isLight ? "slate.2" : "slate.5")}`,
 					userSelect: "none",
+					backgroundSize: "8px 8px"
 				}}
 			>
 				<Group


### PR DESCRIPTION
Added a diagonal-background to tables that are in DROP mode to show they're pseudo-immutable.
Added dashed borders to SCHEMALESS tables to show they're weakly enforced

<img width="1058" height="864" alt="image" src="https://github.com/user-attachments/assets/245c3d56-0a3a-4ab1-8f16-eb9acc435c5a" />
