### PR TITLE
Docker hardening + SBOMs and provenance

### DIFF
--- a/.github/workflows/push-docker.yaml
+++ b/.github/workflows/push-docker.yaml
@@ -55,6 +55,8 @@ jobs:
         with:
           push: true
           file: docker/Dockerfile
+          provenance: mode=max
+          sbom: true
           tags: |
             surrealdb/surrealist:latest
             surrealdb/surrealist:${{ needs.version.outputs.version }}

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -60,6 +60,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           file: docker/Dockerfile
+          provenance: mode=max
+          sbom: true
           tags: |
             surrealdb/surrealist:latest
             surrealdb/surrealist:${{ needs.version.outputs.version }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,9 +24,15 @@ RUN mkdir html
 WORKDIR /
 
 RUN rm /etc/nginx/conf.d/default.conf
+RUN addgroup -S surrealist && adduser -S -D -H -s /sbin/nologin -G surrealist surrealist
+RUN mkdir -p /var/cache/nginx /var/run/nginx /var/log/nginx \
+    && chown -R surrealist:surrealist /var/cache/nginx /var/run/nginx /var/log/nginx
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY ./docker/nginx/nginx.conf /etc/nginx
+RUN chown -R surrealist:surrealist /usr/share/nginx/html /etc/nginx
+
+USER surrealist
 
 EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,4 +1,4 @@
-user nginx;
+pid /var/run/nginx/nginx.pid;
 
 worker_processes    auto;
 


### PR DESCRIPTION
This PR does the following

Gets Docker to generate SBOMs and Provenance attestation upon build, which can be used by consumers for supply chain traceability. 

>  **WARNING**  Note that mode=max exposes the values of [build arguments](https://docs.docker.com/reference/cli/docker/buildx/build/#build-arg).
> 
> If you're misusing build arguments to pass credentials, authentication tokens, or other secrets, you should refactor your build to pass the secrets using [secret mounts](https://docs.docker.com/reference/cli/docker/buildx/build/#secret) instead. Secret mounts don't leak outside of the build and are never included in provenance attestations.

Runs the docker container as non-root (as the `surrealist` user), to align with best practices and to reduce blast radius in the event of container compromise.
