### PR TITLE
Fix blank conversation titles

### DIFF
--- a/src/screens/surrealist/pages/Support/ConversationCard/index.tsx
+++ b/src/screens/surrealist/pages/Support/ConversationCard/index.tsx
@@ -42,7 +42,8 @@ export function ConversationCard({ conversation }: ConversationCardProps) {
 						fw={conversation.read ? 400 : 600}
 						c="bright"
 					>
-						{conversation.title.replace(htmlRegex, "")}
+						{conversation.title?.replace(htmlRegex, "") ||
+							`Conversation #${conversation.id}`}
 					</Text>
 					{!conversation.read && (
 						<Indicator

--- a/src/screens/surrealist/pages/Support/ConversationPage/index.tsx
+++ b/src/screens/surrealist/pages/Support/ConversationPage/index.tsx
@@ -312,7 +312,7 @@ export function ConversationPage({ id }: ConversationPageProps) {
 	const conversationStateMutation = useConversationStateMutation();
 	const replyMutation = useConversationReplyMutation(id);
 
-	const title = conversation?.title.replace(htmlRegex, "");
+	const title = conversation?.title.replace(htmlRegex, "") || `Conversation #${id}`;
 
 	const [replyBody, setReplyBody] = useInputState("");
 	const [attachedFiles, setAttachedFiles] = useInputState<File[]>([]);


### PR DESCRIPTION
If the title of a conversation is empty, a placeholder value is now given.