### PR TITLE
fix: enforce max width for modal content

### DIFF
--- a/src/cloud/style.module.scss
+++ b/src/cloud/style.module.scss
@@ -9,6 +9,10 @@
 	:global(.mantine-Modal-body) {
 		position: relative;
 	}
+	
+	:global(.mantine-Modal-content) {
+		max-width: 99vw;
+	}
 
 	&::before {
 		content: "";


### PR DESCRIPTION
Closes #1122

| Before | After |
|--------|--------|
| <img width="1265" height="1732" alt="image" src="https://github.com/user-attachments/assets/8253325a-5afc-4ea6-a3d2-d58ab25eda5a" /> | <img width="1254" height="1731" alt="image" src="https://github.com/user-attachments/assets/574b94dc-aa9e-45bd-8d7c-6099971f4b96" /> | 

