### PR TITLE
Fix migration exports

### DIFF
--- a/src/screens/surrealist/views/migration/MigrationView/index.tsx
+++ b/src/screens/surrealist/views/migration/MigrationView/index.tsx
@@ -3,6 +3,7 @@ import {
 	Box,
 	Button,
 	Center,
+	Checkbox,
 	Group,
 	Image,
 	Paper,
@@ -29,6 +30,7 @@ import { DiagnosticResource, organizeDiagnostics, ResourceMap } from "./organize
 
 export function MigrationView() {
 	const connectionId = useConnection((c) => c?.id);
+	const [exportVersions, setExportVersions] = useState<boolean>(false);
 
 	// State for opened resource types
 	const [openedTypes, setOpenedTypes] = useState<string[]>([]);
@@ -59,7 +61,7 @@ export function MigrationView() {
 		mutationFn: async () => {
 			const backup = new Blob([
 				await getSurreal().export({
-					versions: true,
+					versions: exportVersions,
 					v3: true,
 				}),
 			]);
@@ -231,7 +233,13 @@ export function MigrationView() {
 							Press the button below to create an export of your database which can be
 							restored in a SurrealDB 3.0 instance.
 						</Text>
-						<Group mt="md">
+						<Checkbox
+							my="md"
+							label="Export historical data (SurrealKV only)"
+							checked={exportVersions}
+							onChange={(event) => setExportVersions(event.currentTarget.checked)}
+						/>
+						<Group>
 							<Button
 								variant="gradient"
 								onClick={() => exportMutation.mutate()}


### PR DESCRIPTION
This PR fixes an issue with exporting via the migration tooling where the file would be blank when downloaded. This was caused by exporting versions by default even when its not supported, resulting in an error. Now, instead of setting by default, this PR adds a checkbox to opt in.

<img width="574" height="473" alt="image" src="https://github.com/user-attachments/assets/d1933a75-a47e-447f-8106-929bc1056922" />