### PR TITLE
Fix strict sandbox option not working

### DIFF
--- a/src/screens/surrealist/connection/surreal.tsx
+++ b/src/screens/surrealist/connection/surreal.tsx
@@ -2,14 +2,10 @@ import { applyDiagnostics, createRemoteEngines, Surreal } from "surrealdb";
 import { useDatabaseStore } from "~/stores/database";
 import { getSetting } from "~/util/config";
 
-export interface SurrealOptions {
-	strict?: boolean;
-}
-
 /**
  * Create a new configured Surreal instance
  */
-export async function createSurreal(_options?: SurrealOptions) {
+export async function createSurreal() {
 	const { createWasmEngines } = await import("@surrealdb/wasm");
 	const { pushDiagnostic } = useDatabaseStore.getState();
 	const maxSize = getSetting("behavior", "diagnosticsHistorySize");
@@ -17,8 +13,6 @@ export async function createSurreal(_options?: SurrealOptions) {
 	const engines = {
 		...createRemoteEngines(),
 		...createWasmEngines({
-			// TODO Why is this missing?
-			// strict: options?.strict,
 			capabilities: {
 				experimental: true,
 				functions: true,


### PR DESCRIPTION
Use the new `STRICT` keyword during sandbox database definition