### PR TITLE
perf: mask nodes when critically zoomed out

### DIFF
--- a/src/screens/surrealist/views/designer/TableGraphPane/index.tsx
+++ b/src/screens/surrealist/views/designer/TableGraphPane/index.tsx
@@ -36,6 +36,7 @@ import {
 	useEdgesState,
 	useNodesInitialized,
 	useNodesState,
+	useOnViewportChange,
 	useReactFlow,
 } from "@xyflow/react";
 import { useContextMenu } from "mantine-contextmenu";
@@ -134,6 +135,7 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 	]);
 
 	const [isExporting, setIsExporting] = useState(false);
+	const [isTiny, setIsTiny] = useState(false);
 	const ref = useRef<ElementRef<"div">>(null);
 	const isLight = useIsLight();
 
@@ -370,6 +372,10 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 		fitView({ duration: 150 });
 	});
 
+	useOnViewportChange({
+		onChange: (vp) => setIsTiny(vp.zoom <= 0.1),
+	});
+
 	const isViewActive = view === "designer";
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: Render on schema or setting change
@@ -552,7 +558,7 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 	});
 
 	return (
-		<DiagramContext.Provider value={{ warnings }}>
+		<DiagramContext.Provider value={{ warnings, isTiny: isTiny && !isExporting }}>
 			<ContentPane
 				title="Table Graph"
 				icon={iconRelation}
@@ -709,11 +715,12 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 						fitView
 						nodes={nodes}
 						edges={edges}
-						minZoom={0.1}
+						minZoom={0.01}
 						nodeTypes={NODE_TYPES}
 						edgeTypes={EDGE_TYPES}
 						nodesConnectable={false}
 						edgesFocusable={false}
+						onlyRenderVisibleElements={!isExporting}
 						proOptions={{ hideAttribution: true }}
 						onNodesChange={onNodesChange}
 						onEdgesChange={onEdgesChange}

--- a/src/screens/surrealist/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
+++ b/src/screens/surrealist/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
@@ -24,6 +24,7 @@ import classes from "../style.module.scss";
 
 export type DiagramContextProps = {
 	warnings?: GraphWarning[];
+	isTiny?: boolean;
 };
 export const DiagramContext = createContext<DiagramContextProps>({});
 
@@ -344,6 +345,7 @@ interface BaseTableNodeProps {
 }
 
 export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: BaseTableNodeProps) {
+	const { isTiny } = useContext(DiagramContext);
 	const isLight = useIsLight();
 	const isLTR = direction === "ltr";
 	const showMore = mode === "summary" || (mode === "fields" && table.fields.length > 0);
@@ -380,23 +382,63 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 		};
 	}, [inField, outField]);
 
-	return (
+	const handles = (
 		<>
 			<Handle
 				type="target"
 				position={isLTR ? Position.Left : Position.Right}
-				style={{
-					visibility: "hidden",
-				}}
+				style={{ visibility: "hidden" }}
 			/>
-
 			<Handle
 				type="source"
 				position={isLTR ? Position.Right : Position.Left}
-				style={{
-					visibility: "hidden",
-				}}
+				style={{ visibility: "hidden" }}
 			/>
+		</>
+	);
+
+	if (isTiny) {
+		return (
+			<>
+				{handles}
+				<Paper
+					px="xs"
+					py={4}
+					bg={isLight ? "white" : "obsidian.6"}
+					shadow={`0 4px 8px rgba(0, 0, 0, ${isLight ? 0.1 : 0.35})`}
+					style={{
+						border: `2px solid ${themeColor(isSelected ? "surreal" : isLight ? "obsidian.2" : "obsidian.5")}`,
+						userSelect: "none",
+						overflow: "hidden",
+						height: "100%",
+						minWidth: 60,
+					}}
+				>
+					<Group
+						gap={4}
+						wrap="nowrap"
+					>
+						<Icon
+							path={TABLE_VARIANT_ICONS[variant]}
+							size="xs"
+							color={isSelected ? "surreal" : isLight ? "obsidian.7" : "obsidian.2"}
+						/>
+						<Text
+							fz="xs"
+							c={isLight ? undefined : "white"}
+							truncate
+						>
+							{table.schema.name}
+						</Text>
+					</Group>
+				</Paper>
+			</>
+		);
+	}
+
+	return (
+		<>
+			{handles}
 
 			<Paper
 				p="md"


### PR DESCRIPTION
This PR adds functionality to the designer that replaces the drawn nodes with basic rectangles for better huge graph performance. This is done at a low zoom level where detail is unreadable anyway.

<img width="602" height="886" alt="image" src="https://github.com/user-attachments/assets/934de7fe-c124-41d7-b628-cbef09523022" />
