### PR TITLE
fix: show event error messages

### DIFF
--- a/src/providers/Inspector/drawer.tsx
+++ b/src/providers/Inspector/drawer.tsx
@@ -140,9 +140,14 @@ export function InspectorDrawer({ opened, history, onClose, onRefresh }: Inspect
 		confirmText: "Delete",
 		skippable: true,
 		onConfirm: async () => {
-			await executeQuery(
+			const [{ success, result }] = await executeQuery(
 				/* surql */ `DELETE ${await getSurrealQL().formatValue(history.current)}`,
 			);
+
+			if (!success) {
+				setError(result.replace("There was a problem with the database: ", ""));
+				return;
+			}
 
 			history.clear();
 


### PR DESCRIPTION
If an event fails during e.g. a delete when viewing the record in the UI, this makes sure that the error is presented and the modal doesn't silently exit