### PR TITLE
Designer: Improved LOD stages, large graph pan performance, fix node height

### DIFF
--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/edges/ElkEdge.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/edges/ElkEdge.tsx
@@ -1,6 +1,7 @@
-import { BaseEdge, type Edge, type EdgeProps, SmoothStepEdge } from "@xyflow/react";
+import { BaseEdge, type Edge, EdgeLabelRenderer, type EdgeProps, SmoothStepEdge } from "@xyflow/react";
 import type { ElkEdgeSection } from "elkjs/lib/elk-api";
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
+import { DiagramContext } from "../nodes/BaseTableNode";
 
 export type ElkEdge = Edge<
 	{
@@ -16,8 +17,10 @@ export function ElkStepEdge({
 	targetX,
 	targetY,
 	data,
+	label,
 	...rest
 }: EdgeProps<ElkEdge>) {
+	const { zoomLevel = 1 } = useContext(DiagramContext);
 	const bendSection = data?.path;
 
 	const edgePath = useMemo(() => {
@@ -161,12 +164,30 @@ export function ElkStepEdge({
 		);
 	}
 
+	const labelScale = Math.min(2, 1 / zoomLevel);
+
 	return (
-		<BaseEdge
-			{...rest}
-			path={edgePath}
-			labelX={labelPosition.x}
-			labelY={labelPosition.y}
-		/>
+		<>
+			<BaseEdge
+				{...rest}
+				path={edgePath}
+			/>
+			{label && (
+				<EdgeLabelRenderer>
+					<div
+						style={{
+							position: "absolute",
+							transform: `translate(-50%, -50%) translate(${labelPosition.x}px, ${labelPosition.y}px) scale(${labelScale})`,
+							pointerEvents: "all",
+							fontSize: 12,
+							fontWeight: 500,
+						}}
+						className="nodrag nopan"
+					>
+						{label}
+					</div>
+				</EdgeLabelRenderer>
+			)}
+		</>
 	);
 }

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/edges/ElkEdge.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/edges/ElkEdge.tsx
@@ -1,4 +1,10 @@
-import { BaseEdge, type Edge, EdgeLabelRenderer, type EdgeProps, SmoothStepEdge } from "@xyflow/react";
+import {
+	BaseEdge,
+	type Edge,
+	EdgeLabelRenderer,
+	type EdgeProps,
+	SmoothStepEdge,
+} from "@xyflow/react";
 import type { ElkEdgeSection } from "elkjs/lib/elk-api";
 import { useContext, useMemo } from "react";
 import { DiagramContext } from "../nodes/BaseTableNode";

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/edges/ElkEdge.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/edges/ElkEdge.tsx
@@ -165,6 +165,7 @@ export function ElkStepEdge({
 	}
 
 	const labelScale = Math.min(2, 1 / zoomLevel);
+	const showLabel = zoomLevel > 0.2; // Hide labels in LOD Level 4
 
 	return (
 		<>
@@ -172,7 +173,7 @@ export function ElkStepEdge({
 				{...rest}
 				path={edgePath}
 			/>
-			{label && (
+			{label && showLabel && (
 				<EdgeLabelRenderer>
 					<div
 						style={{

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/helpers.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/helpers.tsx
@@ -138,7 +138,13 @@ export async function buildFlowNodes(
 
 	// Base height for relational tables (includes in/out fields)
 	// Additional: Divider (10 + 1) + Fields margin (10) + 2 fields (2 * 19) + 1 gap (6)
-	const BASE_HEIGHT_RELATIONAL = BASE_HEIGHT_REGULAR + DIVIDER_MARGIN + DIVIDER_HEIGHT + FIELDS_MARGIN + (2 * FIELD_ROW_HEIGHT) + FIELD_GAP;
+	const BASE_HEIGHT_RELATIONAL =
+		BASE_HEIGHT_REGULAR +
+		DIVIDER_MARGIN +
+		DIVIDER_HEIGHT +
+		FIELDS_MARGIN +
+		2 * FIELD_ROW_HEIGHT +
+		FIELD_GAP;
 
 	// Define all nodes
 	for (const { table, variant } of items) {
@@ -152,15 +158,18 @@ export async function buildFlowNodes(
 
 			// Filter fields (exclude in, out, id for display)
 			const displayFields = table.fields.filter(
-				(f) => f.name !== "in" && f.name !== "out" && f.name !== "id"
+				(f) => f.name !== "in" && f.name !== "out" && f.name !== "id",
 			);
 			const fieldCount = Math.max(displayFields.length, 0);
 
 			if (fieldCount > 0) {
 				// Add divider + fields margin + field rows + gaps between fields
-				const fieldsHeight = DIVIDER_MARGIN + DIVIDER_HEIGHT + FIELDS_MARGIN +
-					(fieldCount * FIELD_ROW_HEIGHT) +
-					((fieldCount - 1) * FIELD_GAP);
+				const fieldsHeight =
+					DIVIDER_MARGIN +
+					DIVIDER_HEIGHT +
+					FIELDS_MARGIN +
+					fieldCount * FIELD_ROW_HEIGHT +
+					(fieldCount - 1) * FIELD_GAP;
 
 				nodeHeight = baseHeight + fieldsHeight;
 			} else if (!isRelation) {

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/helpers.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/helpers.tsx
@@ -180,6 +180,20 @@ export async function buildFlowNodes(
 				// Relational table with no extra fields (just in/out)
 				nodeHeight = baseHeight;
 			}
+		} else if (nodeMode === "summary") {
+			// Summary mode shows 3 rows: Fields count, Indexes count, and Events count
+			const isRelation = variant === "relation";
+			const baseHeight = isRelation ? BASE_HEIGHT_RELATIONAL : BASE_HEIGHT_REGULAR;
+
+			// Add divider + fields margin + 3 summary rows + 2 gaps between them
+			const summaryHeight =
+				DIVIDER_MARGIN +
+				DIVIDER_HEIGHT +
+				FIELDS_MARGIN +
+				3 * FIELD_ROW_HEIGHT +
+				2 * FIELD_GAP;
+
+			nodeHeight = baseHeight + summaryHeight;
 		}
 
 		const node = {

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/helpers.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/helpers.tsx
@@ -122,7 +122,7 @@ export async function buildFlowNodes(
 	// Divider margin: 10px (mt="sm")
 	// Divider height: 1px
 	// Fields Stack margin: 10px (mt={10})
-	// Field row height: 19px (text line height + flex gap)
+	// Field row height: 19.58px (text line height with slight buffer for rendering)
 	// Field gap: 6px (gap="xs" in Stack)
 
 	const PADDING = 32; // p="md" = 16px top + 16px bottom
@@ -130,7 +130,7 @@ export async function buildFlowNodes(
 	const DIVIDER_MARGIN = 10; // mt="sm"
 	const DIVIDER_HEIGHT = 1;
 	const FIELDS_MARGIN = 10; // mt={10}
-	const FIELD_ROW_HEIGHT = 19; // Individual field row
+	const FIELD_ROW_HEIGHT = 19.58; // Individual field row (includes text line-height (source of fractional value))
 	const FIELD_GAP = 6; // gap="xs" between fields
 
 	// Base height for regular tables (no fields shown)

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/helpers.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/helpers.tsx
@@ -116,25 +116,62 @@ export async function buildFlowNodes(
 		}
 	}
 
-	// Height of an individual field row
-	const fieldHeight = 18.59;
-	// Gap between individual field rows
-	const fieldGap = 6;
+	// Static height constants for robust calculation
+	// Paper padding (p="md"): 16px top + 16px bottom = 32px
+	// Header Group: 24px (icon + text height with gap)
+	// Divider margin: 10px (mt="sm")
+	// Divider height: 1px
+	// Fields Stack margin: 10px (mt={10})
+	// Field row height: 19px (text line height + flex gap)
+	// Field gap: 6px (gap="xs" in Stack)
 
-	// padding top + padding bottom + header gap + header height + header margin
-	const staticHeight = 12 + 12 + 9 + fieldHeight + 10;
+	const PADDING = 32; // p="md" = 16px top + 16px bottom
+	const HEADER_HEIGHT = 24; // Icon + text with gap
+	const DIVIDER_MARGIN = 10; // mt="sm"
+	const DIVIDER_HEIGHT = 1;
+	const FIELDS_MARGIN = 10; // mt={10}
+	const FIELD_ROW_HEIGHT = 19; // Individual field row
+	const FIELD_GAP = 6; // gap="xs" between fields
+
+	// Base height for regular tables (no fields shown)
+	const BASE_HEIGHT_REGULAR = PADDING + HEADER_HEIGHT;
+
+	// Base height for relational tables (includes in/out fields)
+	// Additional: Divider (10 + 1) + Fields margin (10) + 2 fields (2 * 19) + 1 gap (6)
+	const BASE_HEIGHT_RELATIONAL = BASE_HEIGHT_REGULAR + DIVIDER_MARGIN + DIVIDER_HEIGHT + FIELDS_MARGIN + (2 * FIELD_ROW_HEIGHT) + FIELD_GAP;
 
 	// Define all nodes
 	for (const { table, variant } of items) {
 		const name = table.schema.name;
 
-		const nodeHeight =
-			nodeMode === "fields"
-				? // field row height, plus the gaps between rows, plus static height.
-					Math.max(table.fields.length, 1) * fieldHeight +
-					(Math.max(table.fields.length, 1) - 1) * fieldGap +
-					staticHeight
-				: undefined;
+		let nodeHeight: number | undefined;
+
+		if (nodeMode === "fields") {
+			const isRelation = variant === "relation";
+			const baseHeight = isRelation ? BASE_HEIGHT_RELATIONAL : BASE_HEIGHT_REGULAR;
+
+			// Filter fields (exclude in, out, id for display)
+			const displayFields = table.fields.filter(
+				(f) => f.name !== "in" && f.name !== "out" && f.name !== "id"
+			);
+			const fieldCount = Math.max(displayFields.length, 0);
+
+			if (fieldCount > 0) {
+				// Add divider + fields margin + field rows + gaps between fields
+				const fieldsHeight = DIVIDER_MARGIN + DIVIDER_HEIGHT + FIELDS_MARGIN +
+					(fieldCount * FIELD_ROW_HEIGHT) +
+					((fieldCount - 1) * FIELD_GAP);
+
+				nodeHeight = baseHeight + fieldsHeight;
+			} else if (!isRelation) {
+				// No fields, show "No fields defined" text
+				// Add divider + margin + text height (19px)
+				nodeHeight = baseHeight + DIVIDER_MARGIN + DIVIDER_HEIGHT + FIELDS_MARGIN + 19;
+			} else {
+				// Relational table with no extra fields (just in/out)
+				nodeHeight = baseHeight;
+			}
+		}
 
 		const node = {
 			id: name,
@@ -148,7 +185,7 @@ export async function buildFlowNodes(
 				mode: nodeMode,
 				links: 0,
 			} as SharedNodeData,
-			height: nodeHeight ? nodeHeight + (variant === "relation" ? 20 : 0) : undefined,
+			height: nodeHeight,
 			width: nodeMode === "fields" ? 250 : undefined,
 		};
 

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/index.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/index.tsx
@@ -136,6 +136,7 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 
 	const [isExporting, setIsExporting] = useState(false);
 	const [isTiny, setIsTiny] = useState(false);
+	const [zoomLevel, setZoomLevel] = useState(1);
 	const ref = useRef<ElementRef<"div">>(null);
 	const isLight = useIsLight();
 
@@ -373,7 +374,10 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 	});
 
 	useOnViewportChange({
-		onChange: (vp) => setIsTiny(vp.zoom <= 0.1),
+		onChange: (vp) => {
+			setIsTiny(vp.zoom <= 0.1);
+			setZoomLevel(vp.zoom);
+		},
 	});
 
 	const isViewActive = view === "designer";
@@ -558,7 +562,7 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 	});
 
 	return (
-		<DiagramContext.Provider value={{ warnings, isTiny: isTiny && !isExporting }}>
+		<DiagramContext.Provider value={{ warnings, isTiny: isTiny && !isExporting, zoomLevel }}>
 			<ContentPane
 				title="Table Graph"
 				icon={iconRelation}
@@ -715,7 +719,7 @@ export function TableGraphPane(props: TableGraphPaneProps) {
 						fitView
 						nodes={nodes}
 						edges={edges}
-						minZoom={0.01}
+						minZoom={0.05}
 						nodeTypes={NODE_TYPES}
 						edgeTypes={EDGE_TYPES}
 						nodesConnectable={false}

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
@@ -25,6 +25,7 @@ import classes from "../style.module.scss";
 export type DiagramContextProps = {
 	warnings?: GraphWarning[];
 	isTiny?: boolean;
+	zoomLevel?: number;
 };
 export const DiagramContext = createContext<DiagramContextProps>({});
 
@@ -345,11 +346,21 @@ interface BaseTableNodeProps {
 }
 
 export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: BaseTableNodeProps) {
-	const { isTiny } = useContext(DiagramContext);
+	const { zoomLevel = 1 } = useContext(DiagramContext);
 	const isLight = useIsLight();
 	const isLTR = direction === "ltr";
 	const showMore = mode === "summary" || (mode === "fields" && table.fields.length > 0);
 	const variant = getTableVariant(table);
+
+	// Calculate LOD level based on zoom (use zoomLevel from context to trigger re-renders)
+	// Level 1: zoom > 0.75 - full detail
+	// Level 2: 0.35 < zoom <= 0.75 - partial detail (skeleton placeholders)
+	// Level 3: 0.2 < zoom <= 0.35 - low detail (table name with inverse scaling)
+	// Level 4: zoom <= 0.2- no detail (just rectangle)
+	const lodLevel = zoomLevel > 0.75 ? 1 : zoomLevel > 0.35 ? 2 : zoomLevel > 0.2 ? 3 : 4;
+
+	// Calculate inverse scale for dashed borders in levels 2 and 3
+	const borderInverseScale = (lodLevel === 2 || lodLevel === 3) && !table.schema.full ? Math.min(3, 1 / zoomLevel) : 1;
 
 	const inField = table.fields.find((f) => f.name === "in");
 	const outField = table.fields.find((f) => f.name === "out");
@@ -397,7 +408,41 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 		</>
 	);
 
-	if (isTiny) {
+	// LOD Level 4: No detail (just rectangle)
+	if (lodLevel === 4) {
+		// Scale pattern size inversely with zoom to remain visible at very low zoom levels
+		const patternSize = Math.max(8, 8 / zoomLevel);
+
+		return (
+			<>
+				{handles}
+				<Paper
+					bg={
+						!table.schema.full
+							? `linear-gradient(-45deg, var(--diagonal-color-2) 12.5%, var(--diagonal-color-1) 12.5%, var(--diagonal-color-1) 50%, var(--diagonal-color-2) 50%, var(--diagonal-color-2) 62.5%, var(--diagonal-color-1) 62.5%, var(--diagonal-color-1) 100%) center / ${patternSize}px ${patternSize}px`
+							: isLight
+								? "white"
+								: "obsidian.6"
+					}
+					style={{
+						"--diagonal-color-1": `var(${isLight ? "white" : "--mantine-color-obsidian-6"})`,
+						"--diagonal-color-2": `var(${isLight ? "--mantine-color-obsidian-1" : "--mantine-color-obsidian-5"})`,
+						border: `2px solid ${themeColor(isSelected ? "surreal" : isLight ? "obsidian.2" : "obsidian.5")}`,
+						userSelect: "none",
+						overflow: "hidden",
+						height: "100%",
+						minWidth: 40,
+					}}
+				/>
+			</>
+		);
+	}
+
+	// LOD Level 3: Low detail (table name with inverse scaling)
+	if (lodLevel === 3) {
+		const borderWidth = 2 * borderInverseScale;
+		const borderStyle = table.schema.full ? "solid" : "dashed";
+
 		return (
 			<>
 				{handles}
@@ -407,16 +452,25 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 					bg={isLight ? "white" : "obsidian.6"}
 					shadow={`0 4px 8px rgba(0, 0, 0, ${isLight ? 0.1 : 0.35})`}
 					style={{
-						border: `2px solid ${themeColor(isSelected ? "surreal" : isLight ? "obsidian.2" : "obsidian.5")}`,
+						border: `${borderWidth}px ${borderStyle} ${themeColor(isSelected ? "surreal" : isLight ? "obsidian.2" : "obsidian.5")}`,
 						userSelect: "none",
 						overflow: "hidden",
 						height: "100%",
 						minWidth: 60,
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
 					}}
 				>
-					<Group
-						gap={4}
-						wrap="nowrap"
+					<Box
+						style={{
+							transform: `scale(${1 / zoomLevel})`,
+							transformOrigin: "center",
+							display: "flex",
+							alignItems: "center",
+							gap: "var(--mantine-spacing-xs)",
+							maxWidth: `${100 * zoomLevel}%`,
+						}}
 					>
 						<Icon
 							path={TABLE_VARIANT_ICONS[variant]}
@@ -430,12 +484,142 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 						>
 							{table.schema.name}
 						</Text>
-					</Group>
+					</Box>
 				</Paper>
 			</>
 		);
 	}
 
+	// LOD Level 2: Partial detail (skeleton text placeholders)
+	if (lodLevel === 2) {
+		const borderWidth = 2 * borderInverseScale;
+		const borderStyle = table.schema.full ? "solid" : "dashed";
+
+		return (
+			<>
+				{handles}
+				<Paper
+					p="md"
+					bg={
+						table.schema.drop
+							? `linear-gradient(-45deg, var(--diagonal-color-2) 12.5%, var(--diagonal-color-1) 12.5%, var(--diagonal-color-1) 50%, var(--diagonal-color-2) 50%, var(--diagonal-color-2) 62.5%, var(--diagonal-color-1) 62.5%, var(--diagonal-color-1) 100%) center / 8px 8px`
+							: isLight
+								? "white"
+								: "obsidian.7"
+					}
+					shadow={`0 8px 12px rgba(0, 0, 0, ${isLight ? 0.075 : 0.2})`}
+					style={{
+						"--diagonal-color-1": `var(${isLight ? "white" : "--mantine-color-obsidian-7"})`,
+						"--diagonal-color-2": `var(${isLight ? "--mantine-color-obsidian-1" : "--mantine-color-obsidian-6"})`,
+						border: `${borderWidth}px ${borderStyle} ${themeColor(isSelected ? "surreal" : isLight ? "obsidian.2" : "obsidian.5")}`,
+						userSelect: "none",
+						backgroundSize: "8px 8px",
+						overflow: "hidden",
+						height: "100%",
+					}}
+				>
+					<Box
+						style={{
+							transform: `scale(${1 / zoomLevel})`,
+							transformOrigin: "left center",
+							display: "flex",
+							alignItems: "center",
+							gap: "var(--mantine-spacing-xs)",
+							maxWidth: `${100 * zoomLevel}%`,
+							color: isLight ? undefined : "white",
+						}}
+					>
+						<Icon
+							path={TABLE_VARIANT_ICONS[variant]}
+							color={isSelected ? "surreal" : isLight ? "obsidian.7" : "obsidian.2"}
+						/>
+						<Text
+							style={{
+								textOverflow: "ellipsis",
+								overflow: "hidden",
+								whiteSpace: "nowrap",
+							}}
+						>
+							{table.schema.name}
+						</Text>
+					</Box>
+
+					{showMore && (
+						<>
+							<Divider
+								color={isLight ? "obsidian.2" : "obsidian.6"}
+								mt="sm"
+							/>
+							<Stack
+								gap="xs"
+								mt={10}
+								p={0}
+							>
+								{mode === "fields"
+									? table.fields
+											.filter((f) => f.name !== "in" && f.name !== "out" && f.name !== "id")
+											.map((field, i) => (
+												<Flex
+													key={i}
+													justify="space-between"
+													gap="xl"
+												>
+													<Box
+														h={16}
+														bg={isLight ? "obsidian.1" : "obsidian.6"}
+														style={{ borderRadius: 4, position: "relative", overflow: "hidden" }}
+													>
+														<Text
+															c={isLight ? undefined : "white"}
+															truncate
+															style={{ opacity: 0, visibility: "hidden" }}
+														>
+															{field.name}
+														</Text>
+													</Box>
+													<Box
+														h={16}
+														bg={isLight ? "obsidian.1" : "obsidian.6"}
+														style={{ borderRadius: 4, position: "relative", overflow: "hidden" }}
+													>
+														<Text
+															c="violet.6"
+															ff="mono"
+															truncate
+															style={{ opacity: 0, visibility: "hidden" }}
+														>
+															{field.kind || "none"}
+														</Text>
+													</Box>
+												</Flex>
+											))
+									: [...Array(Math.min(3, table.fields.length))].map((_, i) => (
+											<Flex
+												key={i}
+												justify="space-between"
+												gap="xl"
+											>
+												<Box
+													h={16}
+													bg={isLight ? "obsidian.1" : "obsidian.6"}
+													style={{ borderRadius: 4, minWidth: 60 }}
+												/>
+												<Box
+													h={16}
+													bg={isLight ? "obsidian.1" : "obsidian.6"}
+													style={{ borderRadius: 4, minWidth: 80 }}
+												/>
+											</Flex>
+										))}
+							</Stack>
+						</>
+					)}
+				</Paper>
+			</>
+		);
+	}
+
+	// LOD Level 1: Full detail
 	return (
 		<>
 			{handles}

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
@@ -416,27 +416,79 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 		// Scale pattern size inversely with zoom to remain visible at very low zoom levels
 		const patternSize = Math.max(8, 8 / zoomLevel);
 
+		// Build tooltip content with table name and fields
+		const displayFields = table.fields.filter(
+			(f) => f.name !== "in" && f.name !== "out" && f.name !== "id",
+		);
+		const tooltipContent = (
+			<Stack gap={4} p={0}>
+				<Text fw={600} size="sm" c={isLight ? "dark.9" : "white"}>
+					{table.schema.name}
+				</Text>
+				{displayFields.length > 0 ? (
+					<Stack gap={2} p={0}>
+						{displayFields.slice(0, 10).map((f) => (
+							<Flex key={f.name} gap="xs" justify="space-between">
+								<Text size="xs" c={isLight ? "dark.7" : "gray.4"}>
+									{f.name}
+								</Text>
+								<Text size="xs" c={isLight ? "violet.7" : "violet.3"} ff="mono">
+									{f.kind || "none"}
+								</Text>
+							</Flex>
+						))}
+						{displayFields.length > 10 && (
+							<Text size="xs" c={isLight ? "dark.5" : "gray.5"} fs="italic" mt={2}>
+								+{displayFields.length - 10} more fields
+							</Text>
+						)}
+					</Stack>
+				) : (
+					<Text size="xs" c={isLight ? "dark.5" : "gray.5"} fs="italic">
+						No fields
+					</Text>
+				)}
+			</Stack>
+		);
+
 		return (
 			<>
 				{handles}
-				<Paper
-					bg={
-						!table.schema.full
-							? `linear-gradient(-45deg, var(--diagonal-color-2) 12.5%, var(--diagonal-color-1) 12.5%, var(--diagonal-color-1) 50%, var(--diagonal-color-2) 50%, var(--diagonal-color-2) 62.5%, var(--diagonal-color-1) 62.5%, var(--diagonal-color-1) 100%) center / ${patternSize}px ${patternSize}px`
-							: isLight
-								? "white"
-								: "obsidian.6"
-					}
-					style={{
-						"--diagonal-color-1": `var(${isLight ? "white" : "--mantine-color-obsidian-6"})`,
-						"--diagonal-color-2": `var(${isLight ? "--mantine-color-obsidian-1" : "--mantine-color-obsidian-5"})`,
-						border: `2px solid ${themeColor(isSelected ? "surreal" : isLight ? "obsidian.2" : "obsidian.5")}`,
-						userSelect: "none",
-						overflow: "hidden",
-						height: "100%",
-						minWidth: 40,
+				<Tooltip
+					label={tooltipContent}
+					position="top"
+					openDelay={300}
+					withArrow
+					multiline
+					w={280}
+					styles={{
+						tooltip: {
+							backgroundColor: isLight
+								? "var(--mantine-color-gray-0)"
+								: "var(--mantine-color-dark-7)",
+							border: isLight ? "1px solid var(--mantine-color-gray-3)" : "none",
+						},
 					}}
-				/>
+				>
+					<Paper
+						bg={
+							!table.schema.full
+								? `linear-gradient(-45deg, var(--diagonal-color-2) 12.5%, var(--diagonal-color-1) 12.5%, var(--diagonal-color-1) 50%, var(--diagonal-color-2) 50%, var(--diagonal-color-2) 62.5%, var(--diagonal-color-1) 62.5%, var(--diagonal-color-1) 100%) center / ${patternSize}px ${patternSize}px`
+								: isLight
+									? "white"
+									: "obsidian.6"
+						}
+						style={{
+							"--diagonal-color-1": `var(${isLight ? "white" : "--mantine-color-obsidian-6"})`,
+							"--diagonal-color-2": `var(${isLight ? "--mantine-color-obsidian-1" : "--mantine-color-obsidian-5"})`,
+							border: `2px solid ${themeColor(isSelected ? "surreal" : isLight ? "obsidian.2" : "obsidian.5")}`,
+							userSelect: "none",
+							overflow: "hidden",
+							height: "100%",
+							minWidth: 40,
+						}}
+					/>
+				</Tooltip>
 			</>
 		);
 	}

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
@@ -212,8 +212,8 @@ function FieldKind({ kind }: FieldKindProps) {
 		<Text
 			c="violet.6"
 			ff="mono"
-			maw="50%"
 			truncate
+			style={{ whiteSpace: "nowrap" }}
 		>
 			<FieldSubKind
 				kind={kind}
@@ -257,15 +257,19 @@ function Field({ isLight, name, value }: FieldProps) {
 			key={name}
 			justify="space-between"
 			gap="xl"
+			style={{ minWidth: 0 }}
 		>
 			<Text
 				title={name}
 				c={isLight ? undefined : "white"}
 				truncate
+				style={{ flex: "1 1 0", minWidth: 0 }}
 			>
 				{name}
 			</Text>
-			{value}
+			<Box style={{ flex: "0 0 auto" }}>
+				{value}
+			</Box>
 		</Flex>
 	);
 }
@@ -353,11 +357,11 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 	const variant = getTableVariant(table);
 
 	// Calculate LOD level based on zoom (use zoomLevel from context to trigger re-renders)
-	// Level 1: zoom > 0.75 - full detail
-	// Level 2: 0.35 < zoom <= 0.75 - partial detail (skeleton placeholders)
+	// Level 1: zoom > 0.5 - full detail
+	// Level 2: 0.35 < zoom <= 0.5 - partial detail (skeleton placeholders)
 	// Level 3: 0.2 < zoom <= 0.35 - low detail (table name with inverse scaling)
 	// Level 4: zoom <= 0.2- no detail (just rectangle)
-	const lodLevel = zoomLevel > 0.75 ? 1 : zoomLevel > 0.35 ? 2 : zoomLevel > 0.2 ? 3 : 4;
+	const lodLevel = zoomLevel > 0.5 ? 1 : zoomLevel > 0.35 ? 2 : zoomLevel > 0.2 ? 3 : 4;
 
 	// Calculate inverse scale for dashed borders in levels 2 and 3
 	const borderInverseScale = (lodLevel === 2 || lodLevel === 3) && !table.schema.full ? Math.min(3, 1 / zoomLevel) : 1;
@@ -544,6 +548,83 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 						</Text>
 					</Box>
 
+					{isEdge && inField && outField && (
+						<>
+							<Divider
+								color={isLight ? "obsidian.2" : "obsidian.6"}
+								my="sm"
+							/>
+							<Stack
+								gap="xs"
+								mt={10}
+								p={0}
+							>
+								<Flex
+									justify="space-between"
+									gap="xl"
+									style={{ minWidth: 0 }}
+								>
+									<Text
+										truncate
+										style={{
+											flex: "1 1 0",
+											minWidth: 0,
+											background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+											borderRadius: 4,
+											color: "transparent"
+										}}
+									>
+										in
+									</Text>
+									<Box style={{ flex: "0 0 auto" }}>
+										<Text
+											truncate
+											style={{
+												background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+												borderRadius: 4,
+												color: "transparent",
+												whiteSpace: "nowrap"
+											}}
+										>
+											{inRecords || "placeholder"}
+										</Text>
+									</Box>
+								</Flex>
+								<Flex
+									justify="space-between"
+									gap="xl"
+									style={{ minWidth: 0 }}
+								>
+									<Text
+										truncate
+										style={{
+											flex: "1 1 0",
+											minWidth: 0,
+											background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+											borderRadius: 4,
+											color: "transparent"
+										}}
+									>
+										out
+									</Text>
+									<Box style={{ flex: "0 0 auto" }}>
+										<Text
+											truncate
+											style={{
+												background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+												borderRadius: 4,
+												color: "transparent",
+												whiteSpace: "nowrap"
+											}}
+										>
+											{outRecords || "placeholder"}
+										</Text>
+									</Box>
+								</Flex>
+							</Stack>
+						</>
+					)}
+
 					{showMore && (
 						<>
 							<Divider
@@ -563,30 +644,30 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 													key={i}
 													justify="space-between"
 													gap="xl"
+													style={{ minWidth: 0 }}
 												>
-													<Box
-														h={16}
-														bg={isLight ? "obsidian.1" : "obsidian.6"}
-														style={{ borderRadius: 4, position: "relative", overflow: "hidden" }}
+													<Text
+														truncate
+														style={{
+															flex: "1 1 0",
+															minWidth: 0,
+															background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+															borderRadius: 4,
+															color: "transparent"
+														}}
 													>
+														{field.name}
+													</Text>
+													<Box style={{ flex: "0 0 auto" }}>
 														<Text
-															c={isLight ? undefined : "white"}
-															truncate
-															style={{ opacity: 0, visibility: "hidden" }}
-														>
-															{field.name}
-														</Text>
-													</Box>
-													<Box
-														h={16}
-														bg={isLight ? "obsidian.1" : "obsidian.6"}
-														style={{ borderRadius: 4, position: "relative", overflow: "hidden" }}
-													>
-														<Text
-															c="violet.6"
 															ff="mono"
 															truncate
-															style={{ opacity: 0, visibility: "hidden" }}
+															style={{
+																background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+																borderRadius: 4,
+																color: "transparent",
+																whiteSpace: "nowrap"
+															}}
 														>
 															{field.kind || "none"}
 														</Text>
@@ -598,17 +679,27 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 												key={i}
 												justify="space-between"
 												gap="xl"
+												style={{ minWidth: 0 }}
 											>
 												<Box
-													h={16}
-													bg={isLight ? "obsidian.1" : "obsidian.6"}
-													style={{ borderRadius: 4, minWidth: 60 }}
+													style={{
+														flex: "1 1 0",
+														minWidth: 60,
+														height: 19,
+														background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+														borderRadius: 4
+													}}
 												/>
-												<Box
-													h={16}
-													bg={isLight ? "obsidian.1" : "obsidian.6"}
-													style={{ borderRadius: 4, minWidth: 80 }}
-												/>
+												<Box style={{ flex: "0 0 auto" }}>
+													<Box
+														style={{
+															minWidth: 80,
+															height: 19,
+															background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+															borderRadius: 4
+														}}
+													/>
+												</Box>
 											</Flex>
 										))}
 							</Stack>
@@ -658,6 +749,7 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 						style={{
 							textOverflow: "ellipsis",
 							overflow: "hidden",
+							whiteSpace: "nowrap",
 						}}
 					>
 						{table.schema.name}

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
@@ -267,9 +267,7 @@ function Field({ isLight, name, value }: FieldProps) {
 			>
 				{name}
 			</Text>
-			<Box style={{ flex: "0 0 auto" }}>
-				{value}
-			</Box>
+			<Box style={{ flex: "0 0 auto" }}>{value}</Box>
 		</Flex>
 	);
 }
@@ -364,7 +362,8 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 	const lodLevel = zoomLevel > 0.5 ? 1 : zoomLevel > 0.35 ? 2 : zoomLevel > 0.2 ? 3 : 4;
 
 	// Calculate inverse scale for dashed borders in levels 2 and 3
-	const borderInverseScale = (lodLevel === 2 || lodLevel === 3) && !table.schema.full ? Math.min(3, 1 / zoomLevel) : 1;
+	const borderInverseScale =
+		(lodLevel === 2 || lodLevel === 3) && !table.schema.full ? Math.min(3, 1 / zoomLevel) : 1;
 
 	const inField = table.fields.find((f) => f.name === "in");
 	const outField = table.fields.find((f) => f.name === "out");
@@ -569,9 +568,11 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 										style={{
 											flex: "1 1 0",
 											minWidth: 0,
-											background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+											background: isLight
+												? "var(--mantine-color-obsidian-1)"
+												: "var(--mantine-color-obsidian-6)",
 											borderRadius: 4,
-											color: "transparent"
+											color: "transparent",
 										}}
 									>
 										in
@@ -580,10 +581,12 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 										<Text
 											truncate
 											style={{
-												background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+												background: isLight
+													? "var(--mantine-color-obsidian-1)"
+													: "var(--mantine-color-obsidian-6)",
 												borderRadius: 4,
 												color: "transparent",
-												whiteSpace: "nowrap"
+												whiteSpace: "nowrap",
 											}}
 										>
 											{inRecords || "placeholder"}
@@ -600,9 +603,11 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 										style={{
 											flex: "1 1 0",
 											minWidth: 0,
-											background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+											background: isLight
+												? "var(--mantine-color-obsidian-1)"
+												: "var(--mantine-color-obsidian-6)",
 											borderRadius: 4,
-											color: "transparent"
+											color: "transparent",
 										}}
 									>
 										out
@@ -611,10 +616,12 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 										<Text
 											truncate
 											style={{
-												background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+												background: isLight
+													? "var(--mantine-color-obsidian-1)"
+													: "var(--mantine-color-obsidian-6)",
 												borderRadius: 4,
 												color: "transparent",
-												whiteSpace: "nowrap"
+												whiteSpace: "nowrap",
 											}}
 										>
 											{outRecords || "placeholder"}
@@ -638,7 +645,12 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 							>
 								{mode === "fields"
 									? table.fields
-											.filter((f) => f.name !== "in" && f.name !== "out" && f.name !== "id")
+											.filter(
+												(f) =>
+													f.name !== "in" &&
+													f.name !== "out" &&
+													f.name !== "id",
+											)
 											.map((field, i) => (
 												<Flex
 													key={i}
@@ -651,9 +663,11 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 														style={{
 															flex: "1 1 0",
 															minWidth: 0,
-															background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+															background: isLight
+																? "var(--mantine-color-obsidian-1)"
+																: "var(--mantine-color-obsidian-6)",
 															borderRadius: 4,
-															color: "transparent"
+															color: "transparent",
 														}}
 													>
 														{field.name}
@@ -663,10 +677,12 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 															ff="mono"
 															truncate
 															style={{
-																background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
+																background: isLight
+																	? "var(--mantine-color-obsidian-1)"
+																	: "var(--mantine-color-obsidian-6)",
 																borderRadius: 4,
 																color: "transparent",
-																whiteSpace: "nowrap"
+																whiteSpace: "nowrap",
 															}}
 														>
 															{field.kind || "none"}
@@ -686,8 +702,10 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 														flex: "1 1 0",
 														minWidth: 60,
 														height: 19,
-														background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
-														borderRadius: 4
+														background: isLight
+															? "var(--mantine-color-obsidian-1)"
+															: "var(--mantine-color-obsidian-6)",
+														borderRadius: 4,
 													}}
 												/>
 												<Box style={{ flex: "0 0 auto" }}>
@@ -695,8 +713,10 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 														style={{
 															minWidth: 80,
 															height: 19,
-															background: isLight ? "var(--mantine-color-obsidian-1)" : "var(--mantine-color-obsidian-6)",
-															borderRadius: 4
+															background: isLight
+																? "var(--mantine-color-obsidian-1)"
+																: "var(--mantine-color-obsidian-6)",
+															borderRadius: 4,
 														}}
 													/>
 												</Box>

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/nodes/BaseTableNode.tsx
@@ -421,30 +421,60 @@ export function BaseTableNode({ table, direction, mode, isSelected, isEdge }: Ba
 			(f) => f.name !== "in" && f.name !== "out" && f.name !== "id",
 		);
 		const tooltipContent = (
-			<Stack gap={4} p={0}>
-				<Text fw={600} size="sm" c={isLight ? "dark.9" : "white"}>
+			<Stack
+				gap={4}
+				p={0}
+			>
+				<Text
+					fw={600}
+					size="sm"
+					c={isLight ? "dark.9" : "white"}
+				>
 					{table.schema.name}
 				</Text>
 				{displayFields.length > 0 ? (
-					<Stack gap={2} p={0}>
+					<Stack
+						gap={2}
+						p={0}
+					>
 						{displayFields.slice(0, 10).map((f) => (
-							<Flex key={f.name} gap="xs" justify="space-between">
-								<Text size="xs" c={isLight ? "dark.7" : "gray.4"}>
+							<Flex
+								key={f.name}
+								gap="xs"
+								justify="space-between"
+							>
+								<Text
+									size="xs"
+									c={isLight ? "dark.7" : "gray.4"}
+								>
 									{f.name}
 								</Text>
-								<Text size="xs" c={isLight ? "violet.7" : "violet.3"} ff="mono">
+								<Text
+									size="xs"
+									c={isLight ? "violet.7" : "violet.3"}
+									ff="mono"
+								>
 									{f.kind || "none"}
 								</Text>
 							</Flex>
 						))}
 						{displayFields.length > 10 && (
-							<Text size="xs" c={isLight ? "dark.5" : "gray.5"} fs="italic" mt={2}>
+							<Text
+								size="xs"
+								c={isLight ? "dark.5" : "gray.5"}
+								fs="italic"
+								mt={2}
+							>
 								+{displayFields.length - 10} more fields
 							</Text>
 						)}
 					</Stack>
 				) : (
-					<Text size="xs" c={isLight ? "dark.5" : "gray.5"} fs="italic">
+					<Text
+						size="xs"
+						c={isLight ? "dark.5" : "gray.5"}
+						fs="italic"
+					>
 						No fields
 					</Text>
 				)}

--- a/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/style.module.scss
+++ b/src/screens/surrealist/pages/Connection/views/designer/TableGraphPane/style.module.scss
@@ -81,6 +81,13 @@
 		// Render the viewport in its own layer (GPU) to improve transform performance
 		// Only done while dragging to reduce blurring of text due to rasterization
 		will-change: transform;
+		text-rendering: optimizeSpeed;
+		backface-visibility: hidden;
+		-webkit-font-smoothing: none;
+	}
+
+	:global(.react-flow__edge) {
+		pointer-events: none;
 	}
 
 	:global(.react-flow .react-flow__edges svg) {


### PR DESCRIPTION
Add 2 more LOD levels for a total of 4, where level 1 has full detail, level 2 is a skeleton, level 3 is just the table name and level 4 is a box. Disables edge label rendering in level 4
Disable edge pointer events, which seems to drastically improve cursor pan performance.
Improve node height calculation (while still technically imperfect, it should be much better)

LOD level 2
<img width="838" height="695" alt="image" src="https://github.com/user-attachments/assets/9d144a96-0b89-481a-9e0d-b4c508db993a" />

Level 3
<img width="533" height="480" alt="image" src="https://github.com/user-attachments/assets/5da6f485-f8e1-4842-80c6-c2938233ba27" />

Level 4
<img width="503" height="463" alt="image" src="https://github.com/user-attachments/assets/54ada651-853b-45fb-82f9-06feae85b455" />
