### PR TITLE
fix: record IDs rendering in light mode when app is dark mode

### DIFF
--- a/src/components/HighlightedText/index.tsx
+++ b/src/components/HighlightedText/index.tsx
@@ -1,5 +1,5 @@
-import { useColorScheme } from "@mantine/hooks";
 import { useMemo } from "react";
+import { useTheme } from "~/hooks/theme";
 import { useConfigStore } from "~/stores/config";
 import { CodeLang } from "~/types";
 import { renderHighlighting } from "~/util/highlighting";
@@ -11,7 +11,7 @@ export interface HighlightedTextProps {
 }
 
 export function HighlightedText({ children, language = "surrealql" }: HighlightedTextProps) {
-	const colorScheme = useColorScheme();
+	const colorScheme = useTheme();
 	const syntaxTheme = useConfigStore((state) => state.settings.appearance.syntaxTheme);
 
 	const highlightedText = useMemo(() => {


### PR DESCRIPTION
Before:
<img width="739" height="185" alt="image" src="https://github.com/user-attachments/assets/e8d0c870-af6f-4f49-987c-803fbdae66ba" />

After:
<img width="747" height="245" alt="image" src="https://github.com/user-attachments/assets/0d762088-2774-434f-a911-848e7b6fc003" />
