### PR TITLE
Use surql-fmt for query and value formatting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "@surrealdb/lezer": "1.0.3",
         "@surrealdb/ql-wasm-2": "npm:@surrealdb/ql-wasm@0.2.0-beta.11",
         "@surrealdb/ql-wasm-3": "npm:@surrealdb/ql-wasm@0.3.1",
+        "@surrealdb/surql-fmt": "^0.1.0-beta.2",
         "@surrealdb/ui": "^1.0.97",
         "@surrealdb/wasm": "^3.0.3",
         "@tanstack/react-query": "^5.37.1",
@@ -536,6 +537,8 @@
     "@surrealdb/ql-wasm-2": ["@surrealdb/ql-wasm@0.2.0-beta.11", "", {}, "sha512-7z9wpksZ8YxM46KiH66ZDBFj4DBfIbVJs80O20inFqqrHVDRqaEM++7LqxtIRpaRzqyhxhYFhyCO5n5+cqbJ4g=="],
 
     "@surrealdb/ql-wasm-3": ["@surrealdb/ql-wasm@0.3.1", "", {}, "sha512-0fRDqhibbbzSrSIw4ertFsN7xgOI8nBx0CipDnMeCYN8Vb9Sc5/ZMahpS2ZTQt1po+k1TmayjlH5CHtx41Iegw=="],
+
+    "@surrealdb/surql-fmt": ["@surrealdb/surql-fmt@0.1.0-beta.2", "", { "dependencies": { "@lezer/common": "^1.5.1", "@surrealdb/lezer": "^1.0.4" }, "peerDependencies": { "typescript": "^5.9.3" }, "bin": { "surqlfmt": "dist/surql-fmt-cli.js" } }, "sha512-uibW3TucV9/P99LtAOpBPnDiN4joPqlCiLEUpK7EOWrrH2T2jWg6uPMI1JlgVun65lBmi4xloxvdeMMNxa2uKA=="],
 
     "@surrealdb/ui": ["@surrealdb/ui@1.0.97", "", { "dependencies": { "@codemirror/legacy-modes": "^6.4.2", "@lezer/common": "^1.2.1", "@lezer/go": "^1.0.0", "@lezer/highlight": "^1.2.1", "@lezer/html": "^1.3.10", "@lezer/javascript": "^1.4.17", "@lezer/json": "^1.0.3", "@lezer/php": "^1.0.2", "@lezer/python": "^1.1.14", "@lezer/rust": "^1.0.2", "@lezer/yaml": "^1.0.3", "@replit/codemirror-indentation-markers": "^6.5.3", "@surrealdb/lezer": "1.0.0-beta.23", "acorn": "^8.16.0", "github-slugger": "^2.0.0", "vite-tsconfig-paths": "^6.0.5" }, "peerDependencies": { "@codemirror/autocomplete": "^6.13.0", "@codemirror/commands": "^6.3.3", "@codemirror/language": "^6.10.1", "@codemirror/lint": "^6.5.0", "@codemirror/search": "^6.5.6", "@codemirror/state": "^6.4.1", "@codemirror/view": "^6.24.1", "@mantine/core": "^8", "@mantine/hooks": "^8", "@yoopta/blockquote": "^6", "@yoopta/callout": "^6", "@yoopta/divider": "^6", "@yoopta/editor": "^6", "@yoopta/headings": "^6", "@yoopta/lists": "^6", "@yoopta/marks": "^6", "@yoopta/paragraph": "^6", "@yoopta/ui": "^6", "react": "^19", "slate": "^0.120.0", "slate-dom": "^0.119.0", "slate-react": "^0.120.0" } }, "sha512-bwftnJTnA9V3oJweVPnNpdtFybRwLERsYqFsOzIhi2iwf+NCMgLaXNidg83ouOwxKIQbb3Kujia9eyaoUdS+qQ=="],
 
@@ -1396,6 +1399,8 @@
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@surrealdb/surql-fmt/@surrealdb/lezer": ["@surrealdb/lezer@1.0.4", "", { "dependencies": { "@lezer/common": "^1.2.3", "@lezer/highlight": "^1.2.1", "@lezer/lr": "^1.4.2" } }, "sha512-y735U11M3BZvX+Beva2UL5R7yrJbpjZBLF+zz26S3XMgeJVk4CR1TzM1IgoHC6kGVkY6uXo1FwL2Wj5GeY/9Mw=="],
 
     "@surrealdb/ui/@surrealdb/lezer": ["@surrealdb/lezer@1.0.0-beta.23", "", { "dependencies": { "@lezer/common": "^1.2.3", "@lezer/highlight": "^1.2.1", "@lezer/lr": "^1.4.2" } }, "sha512-TOF0ktFg5c6vA1G10DXVJdb2Cg+FwBf8KL2Tjl+CM662/MiXykhPmYvp8g+g7q+c2o705EymDg21vsht6nTBGw=="],
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"@surrealdb/lezer": "1.0.3",
 		"@surrealdb/ql-wasm-2": "npm:@surrealdb/ql-wasm@0.2.0-beta.11",
 		"@surrealdb/ql-wasm-3": "npm:@surrealdb/ql-wasm@0.3.1",
+		"@surrealdb/surql-fmt": "^0.1.0-beta.2",
 		"@surrealdb/ui": "^1.0.97",
 		"@surrealdb/wasm": "^3.0.3",
 		"@tanstack/react-query": "^5.37.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,5 +37,8 @@ objc = "0.2.7"
 [target.'cfg(target_os = "linux")'.dependencies]
 openssl = { version = "0.10.72", features = ["vendored"] }
 
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+
 [build-dependencies]
 tauri-build = { version = "2.1.0" }

--- a/src/components/App/modals/highlight-tool.tsx
+++ b/src/components/App/modals/highlight-tool.tsx
@@ -1,14 +1,14 @@
 import { Box, Button, Divider, Modal, Select, SimpleGrid, Stack } from "@mantine/core";
 import { surrealql } from "@surrealdb/codemirror";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { CodeEditor } from "~/components/CodeEditor";
 import { PrimaryTitle } from "~/components/PrimaryTitle";
 import { RadioSelect } from "~/components/RadioSelect";
 import { DRIVERS } from "~/constants";
 import { useBoolean } from "~/hooks/boolean";
+import { useFormatter } from "~/hooks/formatter";
 import { useIntent } from "~/hooks/routing";
 import { useStable } from "~/hooks/stable";
-import { getSurrealQL } from "~/screens/surrealist/connection/connection";
 import { useConfigStore } from "~/stores/config";
 import { CodeLang, type ColorScheme, type SyntaxTheme } from "~/types";
 import { useFeatureFlags } from "~/util/feature-flags";
@@ -116,10 +116,11 @@ interface HighlightToolProps {
 function HighlightTool({ value, onChange, lang }: HighlightToolProps) {
 	const [theme, setTheme] = useState<ColorScheme>("dark");
 	const syntaxTheme = useConfigStore((state) => state.settings.appearance.syntaxTheme);
+	const { format } = useFormatter();
 
-	const format = useCallback(async () => {
-		onChange(await getSurrealQL().formatQuery(value));
-	}, [value, onChange]);
+	const formatQuery = useStable(() => {
+		onChange(format(value));
+	});
 
 	const extensions = useMemo(() => (lang === "cli" ? [surrealql()] : []), [lang]);
 
@@ -155,7 +156,7 @@ function HighlightTool({ value, onChange, lang }: HighlightToolProps) {
 			/>
 			<SimpleGrid cols={2}>
 				<Button
-					onClick={format}
+					onClick={formatQuery}
 					size="xs"
 					color="violet"
 				>

--- a/src/components/DataTable/datatypes.tsx
+++ b/src/components/DataTable/datatypes.tsx
@@ -26,7 +26,7 @@ import {
 	RecordId,
 	Uuid,
 } from "surrealdb";
-import { getSurrealQL } from "~/screens/surrealist/connection/connection";
+import { useFormatter } from "~/hooks/formatter";
 import { TRUNCATE_STYLE } from "~/util/helpers";
 import { GeographyLink } from "../GeographyLink";
 import { RecordLink } from "../RecordLink";
@@ -215,12 +215,13 @@ function ArrayCell(props: { value: any[] }) {
 
 function ObjectCell(props: { value: any }) {
 	const [formatted, setFormatted] = useState("");
+	const { formatValue } = useFormatter();
 
 	useEffect(() => {
 		let cancelled = false;
 
 		const format = async () => {
-			const result = await getSurrealQL().formatValue(props.value, false, true);
+			const result = await formatValue(props.value);
 			if (!cancelled) {
 				setFormatted(result);
 			}
@@ -231,7 +232,7 @@ function ObjectCell(props: { value: any }) {
 		return () => {
 			cancelled = true;
 		};
-	}, [props.value]);
+	}, [props.value, formatValue]);
 
 	return (
 		<div>

--- a/src/components/Inputs/preference.tsx
+++ b/src/components/Inputs/preference.tsx
@@ -39,6 +39,8 @@ export function PreferenceInput({ controller, compact, ...other }: PreferenceInp
 				{...other}
 				value={value}
 				size={compact ? "xs" : undefined}
+				min={controller.options.min}
+				max={controller.options.max}
 				onChange={(input) => {
 					applyPreference(
 						controller.options.writer,

--- a/src/hooks/formatter.ts
+++ b/src/hooks/formatter.ts
@@ -1,10 +1,12 @@
 import { FormatOptions, format, formatRange } from "@surrealdb/surql-fmt";
 import { useStable } from "@surrealdb/ui";
+import { getSurrealQL } from "~/screens/surrealist/connection/connection";
 import { useSetting } from "./config";
 
 export interface Formatters {
 	format: (query: string) => string;
 	formatRange: (query: string, from: number, to: number) => string;
+	formatValue: (value: unknown) => Promise<string>;
 }
 
 /**
@@ -28,5 +30,9 @@ export function useFormatter(): Formatters {
 		formatRange(query, from, to, options),
 	);
 
-	return { format: formatFn, formatRange: formatRangeFn };
+	const formatValueFn = useStable(async (value: unknown) =>
+		format(await getSurrealQL().formatValue(value, false, false)),
+	);
+
+	return { format: formatFn, formatRange: formatRangeFn, formatValue: formatValueFn };
 }

--- a/src/hooks/formatter.ts
+++ b/src/hooks/formatter.ts
@@ -1,0 +1,32 @@
+import { FormatOptions, format, formatRange } from "@surrealdb/surql-fmt";
+import { useStable } from "@surrealdb/ui";
+import { useSetting } from "./config";
+
+export interface Formatters {
+	format: (query: string) => string;
+	formatRange: (query: string, from: number, to: number) => string;
+}
+
+/**
+ * Access SurrealQL formatting functions configured based
+ * on user preferences.
+ */
+export function useFormatter(): Formatters {
+	const [formatIndentSize] = useSetting("appearance", "formatIndentSize");
+	const [formatIndentMode] = useSetting("appearance", "formatIndentMode");
+	const [formatMaxLineLength] = useSetting("appearance", "formatMaxLineLength");
+
+	const options: FormatOptions = {
+		indent: formatIndentMode === "space" ? formatIndentSize : 1,
+		indentChar: formatIndentMode === "space" ? " " : "\t",
+		maxLineLength: formatMaxLineLength,
+	};
+
+	const formatFn = useStable((query: string) => format(query, options));
+
+	const formatRangeFn = useStable((query: string, from: number, to: number) =>
+		formatRange(query, from, to, options),
+	);
+
+	return { format: formatFn, formatRange: formatRangeFn };
+}

--- a/src/screens/surrealist/views/functions/FunctionEditorPanel/index.tsx
+++ b/src/screens/surrealist/views/functions/FunctionEditorPanel/index.tsx
@@ -17,6 +17,7 @@ import {
 } from "~/editor";
 import { useSetting } from "~/hooks/config";
 import { useDatabaseVersionLinter } from "~/hooks/editor";
+import { useFormatter } from "~/hooks/formatter";
 import { useStable } from "~/hooks/stable";
 import { getSurrealQL } from "~/screens/surrealist/connection/connection";
 import type { FunctionDetails, SchemaFunction } from "~/types";
@@ -40,6 +41,7 @@ export function FunctionEditorPanel({
 
 	const [editor, setEditor] = useState<EditorView | null>(null);
 	const surqlVersion = useDatabaseVersionLinter(editor);
+	const { format } = useFormatter();
 
 	const downloadBody = useStable(() => {
 		adapter.saveFile(`Save function`, `${details.name}.surql`, [SURQL_FILTER], () =>
@@ -49,6 +51,7 @@ export function FunctionEditorPanel({
 
 	const formatFunction = useStable(async () => {
 		const isFunctionBlockInvalid = await getSurrealQL().validateQuery(details.block);
+
 		if (isFunctionBlockInvalid) {
 			showErrorNotification({
 				title: "Failed to format",
@@ -56,9 +59,9 @@ export function FunctionEditorPanel({
 			});
 			return;
 		}
-		const formattedFunctionBlock = await getSurrealQL().formatQuery(details.block);
+
 		onChange((draft) => {
-			(draft.details as SchemaFunction).block = formattedFunctionBlock;
+			(draft.details as SchemaFunction).block = format(details.block);
 		});
 	});
 

--- a/src/screens/surrealist/views/functions/FunctionsView/index.tsx
+++ b/src/screens/surrealist/views/functions/FunctionsView/index.tsx
@@ -1,6 +1,5 @@
 import { Box, Button, Group, Modal, Stack, Text, TextInput } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { format } from "@surrealdb/surql-fmt";
 import { Icon, iconChevronRight, iconFunction, iconOpen, iconPlus } from "@surrealdb/ui";
 import { type ChangeEvent, memo, useEffect, useRef, useState } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
@@ -12,6 +11,7 @@ import { PanelDragger } from "~/components/Pane/dragger";
 import { PrimaryTitle } from "~/components/PrimaryTitle";
 import { SidekickPanel } from "~/components/Sidekick/panel";
 import { useConnection, useIsConnected, useRequireDatabase } from "~/hooks/connection";
+import { useFormatter } from "~/hooks/formatter";
 import { usePanelMinSize } from "~/hooks/panels";
 import { useViewFocus } from "~/hooks/routing";
 import { useSaveable } from "~/hooks/save";
@@ -49,6 +49,7 @@ export function FunctionsView() {
 	const [auth] = useConnection((c) => [c?.authentication ?? createBaseAuthentication()]);
 
 	const { functions, models } = useDatabaseSchema();
+	const { format } = useFormatter();
 
 	const [available, setAvailable] = useState<FunctionDetails[]>([]);
 	const [active, setActive] = useImmer<FunctionDetails | null>(null);

--- a/src/screens/surrealist/views/functions/FunctionsView/index.tsx
+++ b/src/screens/surrealist/views/functions/FunctionsView/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Group, Modal, Stack, Text, TextInput } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
+import { format } from "@surrealdb/surql-fmt";
 import { Icon, iconChevronRight, iconFunction, iconOpen, iconPlus } from "@surrealdb/ui";
 import { type ChangeEvent, memo, useEffect, useRef, useState } from "react";
 import { Panel, PanelGroup } from "react-resizable-panels";
@@ -145,7 +146,7 @@ export function FunctionsView() {
 		} else {
 			const f = func.details as SchemaFunction;
 			const isInvalid = await getSurrealQL().validateQuery(f.block);
-			const block = isInvalid ? f.block : await getSurrealQL().formatQuery(f.block);
+			const block = isInvalid ? f.block : format(f.block);
 
 			setActive({
 				type: "function",

--- a/src/screens/surrealist/views/graphql/QueryPane/index.tsx
+++ b/src/screens/surrealist/views/graphql/QueryPane/index.tsx
@@ -25,9 +25,9 @@ import {
 } from "~/editor";
 import { useConnection } from "~/hooks/connection";
 import { useDebouncedFunction } from "~/hooks/debounce";
+import { useFormatter } from "~/hooks/formatter";
 import { useConnectionAndView, useIntent } from "~/hooks/routing";
 import { useStable } from "~/hooks/stable";
-import { getSurrealQL } from "~/screens/surrealist/connection/connection";
 import { useConfigStore } from "~/stores/config";
 import { showErrorNotification, showInfo, tryParseParams } from "~/util/helpers";
 import classes from "./style.module.scss";
@@ -57,6 +57,7 @@ export function QueryPane({
 }: QueryPaneProps) {
 	const [connection] = useConnectionAndView();
 	const { updateConnection } = useConfigStore.getState();
+	const { formatValue } = useFormatter();
 	const queryText = useConnection((c) => c?.graphqlQuery ?? "");
 
 	const setQueryForced = useStable((query: string) => {
@@ -137,7 +138,7 @@ export function QueryPane({
 			setShowVariables(true);
 			updateConnection({
 				id: connection,
-				graphqlVariables: await getSurrealQL().formatValue(mergedVars, false, true),
+				graphqlVariables: await formatValue(mergedVars),
 			});
 		} catch {
 			showErrorNotification({

--- a/src/screens/surrealist/views/migration/ResourceDetailPanel/index.tsx
+++ b/src/screens/surrealist/views/migration/ResourceDetailPanel/index.tsx
@@ -27,8 +27,8 @@ import { ActionButton } from "~/components/ActionButton";
 import { RecordLink } from "~/components/RecordLink";
 import { Spacer } from "~/components/Spacer";
 import { SURQL_FILTER } from "~/constants";
+import { useFormatter } from "~/hooks/formatter";
 import { useIsLight } from "~/hooks/theme";
-import { getSurrealQL } from "~/screens/surrealist/connection/connection";
 import { MigrationKind, MigrationResourceType, MigrationSeverity } from "~/types";
 import { kindMeta } from "../MigrationView/kinds";
 import { DiagnosticEntry, DiagnosticResource } from "../MigrationView/organizer";
@@ -370,6 +370,8 @@ function GroupedKindCard({ index, group, resolvedIds, onToggleAll }: GroupedKind
 	const unresolvedCount = group.entries.filter((e) => !resolvedIds.has(e.id)).length;
 	const allResolved = unresolvedCount === 0;
 
+	const { formatValue } = useFormatter();
+
 	const handleOpenDocs = () => {
 		if (kind?.documentationUrl) {
 			adapter.openUrl(kind.documentationUrl);
@@ -378,7 +380,7 @@ function GroupedKindCard({ index, group, resolvedIds, onToggleAll }: GroupedKind
 
 	const handleDownloadRecords = async () => {
 		const recordIds = group.entries.map((entry) => entry.record).filter(Boolean);
-		const surql = await getSurrealQL().formatValue(recordIds, false, true);
+		const surql = await formatValue(recordIds);
 		const kindSlug = group.kind.replace(/\s+/g, "-").toLowerCase();
 
 		adapter.saveFile(

--- a/src/screens/surrealist/views/query/QueryPane/index.tsx
+++ b/src/screens/surrealist/views/query/QueryPane/index.tsx
@@ -4,7 +4,6 @@ import { EditorState, Prec, type SelectionRange } from "@codemirror/state";
 import { type EditorView, keymap, scrollPastEnd } from "@codemirror/view";
 import { Button, Group, HoverCard, Paper, rem, Text, ThemeIcon, Transition } from "@mantine/core";
 import { surrealql } from "@surrealdb/codemirror";
-import { FormatOptions, format, formatRange } from "@surrealdb/surql-fmt";
 import {
 	Icon,
 	iconAutoFix,
@@ -35,6 +34,7 @@ import { setEditorText } from "~/editor/helpers";
 import { useSetting } from "~/hooks/config";
 import { useConnection } from "~/hooks/connection";
 import { useDatabaseVersionLinter } from "~/hooks/editor";
+import { useFormatter } from "~/hooks/formatter";
 import { useConnectionAndView, useIntent } from "~/hooks/routing";
 import { useStable } from "~/hooks/stable";
 import { useIsLight } from "~/hooks/theme";
@@ -50,10 +50,6 @@ import { readQuery, writeQuery } from "../QueryView/strategy";
 
 const SERIALIZE = {
 	history: historyField,
-};
-
-const FORMAT_OPTS: FormatOptions = {
-	indent: 4,
 };
 
 export interface QueryPaneProps {
@@ -84,6 +80,7 @@ export function QueryPane({
 	onEditorMounted,
 }: QueryPaneProps) {
 	const isLight = useIsLight();
+	const { format, formatRange } = useFormatter();
 	const { updateQueryTab, updateConnection } = useConfigStore.getState();
 	const { updateQueryState, setQueryValid } = useQueryStore.getState();
 	const { inspect } = useInspector();
@@ -151,12 +148,9 @@ export function QueryPane({
 			const document = editor.state.doc.toString();
 
 			if (hasSelection) {
-				setEditorText(
-					editor,
-					formatRange(document, selection.from, selection.to, FORMAT_OPTS),
-				);
+				setEditorText(editor, formatRange(document, selection.from, selection.to));
 			} else {
-				setEditorText(editor, format(document, FORMAT_OPTS));
+				setEditorText(editor, format(document));
 			}
 		} catch {
 			showErrorNotification({

--- a/src/screens/surrealist/views/query/QueryPane/index.tsx
+++ b/src/screens/surrealist/views/query/QueryPane/index.tsx
@@ -39,7 +39,6 @@ import { useConnectionAndView, useIntent } from "~/hooks/routing";
 import { useStable } from "~/hooks/stable";
 import { useIsLight } from "~/hooks/theme";
 import { useInspector } from "~/providers/Inspector";
-import { getSurrealQL } from "~/screens/surrealist/connection/connection";
 import { useConfigStore } from "~/stores/config";
 import { useQueryStore } from "~/stores/query";
 import type { QueryTab } from "~/types";
@@ -80,7 +79,7 @@ export function QueryPane({
 	onEditorMounted,
 }: QueryPaneProps) {
 	const isLight = useIsLight();
-	const { format, formatRange } = useFormatter();
+	const { format, formatRange, formatValue } = useFormatter();
 	const { updateQueryTab, updateConnection } = useConfigStore.getState();
 	const { updateQueryState, setQueryValid } = useQueryStore.getState();
 	const { inspect } = useInspector();
@@ -181,10 +180,11 @@ export function QueryPane({
 			...currentVars,
 			...newVars,
 		};
-		-setShowVariables(true);
+
+		setShowVariables(true);
 		updateQueryTab(connection, {
 			id: activeTab.id,
-			variables: await getSurrealQL().formatValue(mergedVars, false, true),
+			variables: await formatValue(mergedVars),
 		});
 	});
 

--- a/src/screens/surrealist/views/query/QueryPane/index.tsx
+++ b/src/screens/surrealist/views/query/QueryPane/index.tsx
@@ -4,6 +4,7 @@ import { EditorState, Prec, type SelectionRange } from "@codemirror/state";
 import { type EditorView, keymap, scrollPastEnd } from "@codemirror/view";
 import { Button, Group, HoverCard, Paper, rem, Text, ThemeIcon, Transition } from "@mantine/core";
 import { surrealql } from "@surrealdb/codemirror";
+import { format, formatRange } from "@surrealdb/surql-fmt";
 import {
 	Icon,
 	iconAutoFix,
@@ -143,16 +144,13 @@ export function QueryPane({
 		if (!editor) return;
 
 		try {
-			const document = editor.state.doc;
-			const formatted = hasSelection
-				? document.sliceString(0, selection.from) +
-					(await getSurrealQL().formatQuery(
-						document.sliceString(selection.from, selection.to),
-					)) +
-					document.sliceString(selection.to)
-				: await getSurrealQL().formatQuery(document.toString());
+			const document = editor.state.doc.toString();
 
-			setEditorText(editor, formatted);
+			if (hasSelection) {
+				setEditorText(editor, formatRange(document, selection.from, selection.to));
+			} else {
+				setEditorText(editor, format(document));
+			}
 		} catch {
 			showErrorNotification({
 				title: "Failed to format",

--- a/src/screens/surrealist/views/query/QueryPane/index.tsx
+++ b/src/screens/surrealist/views/query/QueryPane/index.tsx
@@ -4,7 +4,7 @@ import { EditorState, Prec, type SelectionRange } from "@codemirror/state";
 import { type EditorView, keymap, scrollPastEnd } from "@codemirror/view";
 import { Button, Group, HoverCard, Paper, rem, Text, ThemeIcon, Transition } from "@mantine/core";
 import { surrealql } from "@surrealdb/codemirror";
-import { format, formatRange } from "@surrealdb/surql-fmt";
+import { FormatOptions, format, formatRange } from "@surrealdb/surql-fmt";
 import {
 	Icon,
 	iconAutoFix,
@@ -50,6 +50,10 @@ import { readQuery, writeQuery } from "../QueryView/strategy";
 
 const SERIALIZE = {
 	history: historyField,
+};
+
+const FORMAT_OPTS: FormatOptions = {
+	indent: 4,
 };
 
 export interface QueryPaneProps {
@@ -147,9 +151,12 @@ export function QueryPane({
 			const document = editor.state.doc.toString();
 
 			if (hasSelection) {
-				setEditorText(editor, formatRange(document, selection.from, selection.to));
+				setEditorText(
+					editor,
+					formatRange(document, selection.from, selection.to, FORMAT_OPTS),
+				);
 			} else {
-				setEditorText(editor, format(document));
+				setEditorText(editor, format(document, FORMAT_OPTS));
 			}
 		} catch {
 			showErrorNotification({

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -226,6 +226,9 @@ export interface SurrealistAppearanceSettings {
 	queryOrientation: Orientation;
 	sidebarViews: Flags<ViewPage>;
 	disableAnimations: boolean;
+	formatIndentSize: number;
+	formatIndentMode: "space" | "tab";
+	formatMaxLineLength: number;
 }
 
 export interface SurrealistTemplateSettings {

--- a/src/util/defaults.tsx
+++ b/src/util/defaults.tsx
@@ -77,6 +77,9 @@ export function createBaseSettings(): SurrealistSettings {
 			queryOrientation: "vertical",
 			sidebarViews: {},
 			disableAnimations: false,
+			formatIndentSize: 4,
+			formatIndentMode: "space",
+			formatMaxLineLength: 120,
 		},
 		templates: {
 			list: [],

--- a/src/util/preferences.tsx
+++ b/src/util/preferences.tsx
@@ -17,6 +17,7 @@ import {
 	THEMES,
 	VIEW_PAGES,
 } from "~/constants";
+import { useSetting } from "~/hooks/config";
 import { Flags, type Listable, Selectable, type SurrealistConfig } from "~/types";
 import { useFeatureFlags } from "./feature-flags";
 import { optional } from "./helpers";
@@ -57,7 +58,7 @@ export class CheckboxController {
  * A preference controller for a number
  */
 export class NumberController {
-	constructor(public options: ReaderWriter<number>) {}
+	constructor(public options: ReaderWriter<number> & { min?: number; max?: number }) {}
 }
 
 /**
@@ -95,6 +96,8 @@ export function useComputedPreferences(): PreferenceSection[] {
 	const [
 		{ themes, syntax_themes, cloud_endpoints, gtm_debug, sidebar_customization, website_base },
 	] = useFeatureFlags();
+
+	const [currentFormatIndentMode] = useSetting("appearance", "formatIndentMode");
 
 	return useMemo(() => {
 		const sections: PreferenceSection[] = [];
@@ -283,6 +286,51 @@ export function useComputedPreferences(): PreferenceSection[] {
 							},
 						}),
 					},
+					{
+						id: "format-max-line-length",
+						name: "Format max line length",
+						description: "The maximum line length for formatted queries",
+						controller: new NumberController({
+							min: 1,
+							max: 300,
+							reader: (config) => config.settings.appearance.formatMaxLineLength,
+							writer: (config, value) => {
+								config.settings.appearance.formatMaxLineLength = value;
+							},
+						}),
+					},
+					{
+						id: "format-indentation-mode",
+						name: "Format indentation mode",
+						description: "Configure how queries are indented during formatting",
+						controller: new SelectionController({
+							options: [
+								{ label: "Space", value: "space" },
+								{ label: "Tab", value: "tab" },
+							],
+							reader: (config) => config.settings.appearance.formatIndentMode,
+							writer: (config, value) => {
+								config.settings.appearance.formatIndentMode = value as
+									| "space"
+									| "tab";
+							},
+						}),
+					},
+					...optional(
+						currentFormatIndentMode === "space" && {
+							id: "format-indentation-size",
+							name: "Format indentation size",
+							description: "The indentation level for formatted queries",
+							controller: new NumberController({
+								min: 1,
+								max: 10,
+								reader: (config) => config.settings.appearance.formatIndentSize,
+								writer: (config, value) => {
+									config.settings.appearance.formatIndentSize = value;
+								},
+							}),
+						},
+					),
 				],
 			},
 			{
@@ -656,7 +704,15 @@ export function useComputedPreferences(): PreferenceSection[] {
 		}
 
 		return sections;
-	}, [cloud_endpoints, website_base, gtm_debug, sidebar_customization, syntax_themes, themes]);
+	}, [
+		cloud_endpoints,
+		website_base,
+		gtm_debug,
+		sidebar_customization,
+		syntax_themes,
+		themes,
+		currentFormatIndentMode,
+	]);
 }
 
 function nodef<T extends string>(items: Selectable<T>[]) {

--- a/src/util/surql/v2.tsx
+++ b/src/util/surql/v2.tsx
@@ -62,8 +62,8 @@ export class SurrealQLV2 implements SurrealQL {
 		return Promise.resolve(result);
 	}
 
-	formatQuery(query: string, pretty = true): Promise<string> {
-		return Promise.resolve(Wasm.format(query, pretty));
+	formatQuery(): Promise<string> {
+		throw new Error("Use of legacy formatter is no longer supported");
 	}
 
 	extractKindRecords(kind: string): Promise<string[]> {

--- a/src/util/surql/v3.tsx
+++ b/src/util/surql/v3.tsx
@@ -55,8 +55,8 @@ export class SurrealQLV3 implements SurrealQL {
 		return Promise.resolve(indexes);
 	}
 
-	formatQuery(query: string, pretty = true): Promise<string> {
-		return Promise.resolve(Wasm.format(query, pretty));
+	formatQuery(): Promise<string> {
+		throw new Error("Use of legacy formatter is no longer supported");
 	}
 
 	extractKindRecords(kind: string): Promise<string[]> {


### PR DESCRIPTION
Update the formatter to use `surql-fmt` instead of database pretty printing for higher quality formatting.

## Benefits
- Conditional wrapping
- Multi-level indenting
- Graceful error handling
- Intelligent selection formatting
- Format customisation (indenting, max line length)
- Value formatting

## Example
<details>
<summary>Screenshots</summary>

### Before
<img width="1715" height="944" alt="image" src="https://github.com/user-attachments/assets/9e678551-0a51-4bbc-9d7e-f49e1222f953" />

### After
<img width="1715" height="948" alt="image" src="https://github.com/user-attachments/assets/31ad1e10-d172-48b3-864b-78063e21dfd9" />
</details>