### PR TITLE
fix(linux): pass URLs through desktop launcher

### DIFF
--- a/src-tauri/res/desktop-template.desktop.hbs
+++ b/src-tauri/res/desktop-template.desktop.hbs
@@ -4,9 +4,11 @@ Categories={{categories}}
 Comment={{comment}}
 {{/if}}
 Exec={{exec}} %U
+StartupWMClass={{exec}}
 Icon={{icon}}
 Name={{name}}
-Type=Application
 Terminal=false
-# Keep this in sync with tauri.conf.json bundle.fileAssociations and the deep-link scheme.
-MimeType=text/x-surrealql;x-scheme-handler/surrealist;
+Type=Application
+{{#if mime_type}}
+MimeType={{mime_type}}
+{{/if}}

--- a/src-tauri/res/desktop-template.desktop.hbs
+++ b/src-tauri/res/desktop-template.desktop.hbs
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}
+Comment={{comment}}
+{{/if}}
+Exec={{exec}} %U
+Icon={{icon}}
+Name={{name}}
+Type=Application
+Terminal=false
+MimeType=text/x-surrealql;x-scheme-handler/surrealist

--- a/src-tauri/res/desktop-template.desktop.hbs
+++ b/src-tauri/res/desktop-template.desktop.hbs
@@ -8,4 +8,5 @@ Icon={{icon}}
 Name={{name}}
 Type=Application
 Terminal=false
+# Keep this in sync with tauri.conf.json bundle.fileAssociations and the deep-link scheme.
 MimeType=text/x-surrealql;x-scheme-handler/surrealist;

--- a/src-tauri/res/desktop-template.desktop.hbs
+++ b/src-tauri/res/desktop-template.desktop.hbs
@@ -8,4 +8,4 @@ Icon={{icon}}
 Name={{name}}
 Type=Application
 Terminal=false
-MimeType=text/x-surrealql;x-scheme-handler/surrealist
+MimeType=text/x-surrealql;x-scheme-handler/surrealist;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,7 +41,11 @@
 		],
 		"linux": {
 			"deb": {
-				"depends": []
+				"depends": [],
+				"desktopTemplate": "res/desktop-template.desktop.hbs"
+			},
+			"rpm": {
+				"desktopTemplate": "res/desktop-template.desktop.hbs"
 			}
 		},
 		"macOS": {


### PR DESCRIPTION
## Issue

Signing in to to your [SurrealDB account](https://auth.surrealdb.com) is not possible when using the `.deb` installer.

**Relates to:** #954 

<img width="356" height="119" alt="image" src="https://github.com/user-attachments/assets/661e5d41-1b02-4ba1-84c9-07b039021fa8" />

## Cause

The OAuth callback URL is not passed as an argument to the `surrealist` executable when passing it to the `.desktop` launcher.

## Solution

Alter the generated `.desktop` file by using a handlebars template to pass URLs.

```diff
[Desktop Entry]
Categories=Development;
-Exec=surrealist
+Exec=surrealist %U
Icon=surrealist
Name=Surrealist
Terminal=false
Type=Application
MimeType=text/x-surrealql;x-scheme-handler/surrealist
```

## Choices made

- Using a handlebars template seems like the most correct way to work around this issue as there doesn't seem to be a more specific flag in the Tauri configuration to pass arguments to the `surrealist` command in the launcher in another way.
- Passing `%U` (multiple URLs) instead of `%u` (single URL) as the macOS seems to support multiple URLs too.
  https://github.com/surrealdb/surrealist/blob/78f7c435cbd72aa1bcc5e11ef5781e890d99b482/src-tauri/src/main.rs#L128
  - **NOTE:** I believe this isn't the case for Windows, as I think `%1` means it picks only the first URL.  
    https://github.com/surrealdb/surrealist/blob/78f7c435cbd72aa1bcc5e11ef5781e890d99b482/src-tauri/res/installer.nsi#L561
- Added `MimeType` manually as it seemed missing in the variables provided by Tauri in their official documentation

## Notes

- It might be worth checking out whether other arguments than URLs need to be supported, as this feature constrains the passed references to URLs and not files, for example.
- ! Signing out doesn't seem to work either. Is this a regression?

## Verification

- [x] The `%U` flag works when manually editing the `.desktop` file after installing the current official release `3.7.4`
- [x] The `.deb` build creates the `.desktop` file correctly in `/usr/share/applications/Surrealist.desktop`
- [ ] ~~The `.deb` build works locally~~
- [ ] The `.rpm` build works

> [!CAUTION]
> I was not able to get the `.deb` version to run correctly after the build due to my local setup, nor did I test the `rpm` version as I'm running Ubuntu.
> AppImage didn't support a flag like this, and I'm not sure whether that's impacted.
> ⇒ Please verify these cases before merging

## References

> `tauri.conf.json`

- [`bundle.linux.deb.desktopTemplate`](https://v2.tauri.app/reference/config/#desktoptemplate) (Tauri Documentation)
- [`bundle.linux.rpm.desktopTemplate`](https://v2.tauri.app/reference/config/#desktoptemplate-1) (Tauri Documentation)

> `.desktop`

- [`Exec=` variables](https://specifications.freedesktop.org/desktop-entry/latest/exec-variables.html) (Desktop Entry Specification)