### PR TITLE
fix: pass deep-link URL to Linux desktop Exec

### DIFF
--- a/src-tauri/linux/main.desktop
+++ b/src-tauri/linux/main.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}
+Comment={{comment}}
+{{/if}}
+Exec={{exec}} %u
+Icon={{icon}}
+Name={{name}}
+Terminal=false
+Type=Application
+{{#if mime_type}}
+MimeType={{mime_type}}
+{{/if}}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -41,7 +41,11 @@
 		],
 		"linux": {
 			"deb": {
-				"depends": []
+				"depends": [],
+				"desktopTemplate": "linux/main.desktop"
+			},
+			"rpm": {
+				"desktopTemplate": "linux/main.desktop"
 			}
 		},
 		"macOS": {


### PR DESCRIPTION
Tauri's bundled .desktop template omits %u/%U, so browser-invoked surrealist:// callbacks (e.g. the sign-in redirect) launch the app but drop the URL. Override the template via desktopTemplate for deb and rpm so Exec=surrealist %u receives the callback.

Fixes #954
Upstream: tauri-apps/tauri#10570