### PR TITLE
Add bunfig with minimumReleaseAge for supply-chain safety

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,8 +1,8 @@
 [install]
-# Only install package versions published at least 3 days ago
-minimumReleaseAge = 259200
+# Only install package versions published at least 7 days ago
+minimumReleaseAge = 604800
 
-# These packages will bypass the 3-day minimum age requirement
+# These packages will bypass the 7-day minimum age requirement
 minimumReleaseAgeExcludes = [
 	"@types/bun",
 	"typescript",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,17 @@
+[install]
+# Only install package versions published at least 3 days ago
+minimumReleaseAge = 259200
+
+# These packages will bypass the 3-day minimum age requirement
+minimumReleaseAgeExcludes = [
+	"@types/bun",
+	"typescript",
+	"surrealdb",
+	"@surrealdb/wasm",
+	"@surrealdb/lezer",
+	"@surrealdb/codemirror",
+	"@surrealdb/surql-fmt",
+	"@surrealdb/ql-wasm",
+	"@surrealdb/cbor",
+	"@surrealdb/ui",
+]


### PR DESCRIPTION
Adds root `bunfig.toml`: `minimumReleaseAge` (3 days) and `minimumReleaseAgeExcludes`. Improves supply-chain safety for CI and contributors.