### PR TITLE
Update codeowners to Surrealist team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for the repository
-* @macjuul @ItsMateo
+* @surrealdb/Surrealist

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for the repository
-* @surrealdb/Surrealist
+* @surrealdb/surrealist


### PR DESCRIPTION
Right now both Matt and Julian are required to both approve the PR. Changing that to be a single Surrealist team solves that by requiring approval from only 1 member