### PR TITLE
Spectron context: scoped document uploads, grant verbs, pagination & SDK bump

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "surrealist",
@@ -46,7 +45,7 @@
         "@surrealdb/lezer": "1.0.3",
         "@surrealdb/ql-wasm-2": "npm:@surrealdb/ql-wasm@0.2.0-beta.11",
         "@surrealdb/ql-wasm-3": "npm:@surrealdb/ql-wasm@0.3.1",
-        "@surrealdb/spectron": "1.0.0-alpha.1",
+        "@surrealdb/spectron": "1.0.0-alpha.2",
         "@surrealdb/surql-fmt": "^0.1.0-beta.2",
         "@surrealdb/ui": "^1.2.3",
         "@surrealdb/wasm": "^3.0.3",
@@ -526,7 +525,7 @@
 
     "@surrealdb/ql-wasm-3": ["@surrealdb/ql-wasm@0.3.1", "", {}, "sha512-0fRDqhibbbzSrSIw4ertFsN7xgOI8nBx0CipDnMeCYN8Vb9Sc5/ZMahpS2ZTQt1po+k1TmayjlH5CHtx41Iegw=="],
 
-    "@surrealdb/spectron": ["@surrealdb/spectron@1.0.0-alpha.1", "", { "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" } }, "sha512-ECGMp7w0iwZ+EYV0dErOnBOpQvUl6gpmaNn212Nrn2SQRq+zMaJ0eaj/sPukuLl8BqRzqKHgaOjXoESBna/ufw=="],
+    "@surrealdb/spectron": ["@surrealdb/spectron@1.0.0-alpha.2", "", { "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" } }, "sha512-oSmsfXy/zUOoH3nHVPMSJpKE9hK2nZstlRKNyv1IY+w8v4fLTine2SBC6UcJMIYR/FyLXqMtUseO7/7dSxOH2A=="],
 
     "@surrealdb/surql-fmt": ["@surrealdb/surql-fmt@0.1.0-beta.2", "", { "dependencies": { "@lezer/common": "^1.5.1", "@surrealdb/lezer": "^1.0.4" }, "peerDependencies": { "typescript": "^5.9.3" }, "bin": { "surqlfmt": "dist/surql-fmt-cli.js" } }, "sha512-uibW3TucV9/P99LtAOpBPnDiN4joPqlCiLEUpK7EOWrrH2T2jWg6uPMI1JlgVun65lBmi4xloxvdeMMNxa2uKA=="],
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"@surrealdb/lezer": "1.0.3",
 		"@surrealdb/ql-wasm-2": "npm:@surrealdb/ql-wasm@0.2.0-beta.11",
 		"@surrealdb/ql-wasm-3": "npm:@surrealdb/ql-wasm@0.3.1",
-		"@surrealdb/spectron": "1.0.0-alpha.1",
+		"@surrealdb/spectron": "1.0.0-alpha.2",
 		"@surrealdb/surql-fmt": "^0.1.0-beta.2",
 		"@surrealdb/ui": "^1.2.3",
 		"@surrealdb/wasm": "^3.0.3",

--- a/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
@@ -34,7 +34,8 @@ import {
 	pictoDocumentGradient,
 } from "@surrealdb/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRef, useState } from "react";
+import { Fragment, useRef, useState } from "react";
+import type { SpectronScopeSets } from "~/types";
 import { formatFileSize, showErrorNotification, showInfo } from "~/util/helpers";
 import { ContextHero } from "../../components/ContextHero";
 import { EmptyState, PageError, SpectronGate } from "../../components/feedback";
@@ -98,7 +99,8 @@ function DocumentExplorer({ client }: { client: Spectron }) {
 
 	const listQuery = useQuery({
 		queryKey: listQueryKey,
-		queryFn: () => client.documents.list({ page, pageSize: PAGE_SIZE }),
+		// Mantine's Pagination is 1-based; the API expects a 0-indexed page.
+		queryFn: () => client.documents.list({ page: page - 1, pageSize: PAGE_SIZE }),
 		retry: false,
 		placeholderData: (prev) => prev,
 		// Poll while anything is still being processed so statuses advance live.
@@ -738,7 +740,8 @@ function InspectorBody({
 	const chunksQuery = useQuery({
 		queryKey: ["spectron", client.contextId, "documents", "chunks", doc.id, chunkPage],
 		queryFn: () =>
-			client.documents.chunks(doc.id, { page: chunkPage, pageSize: CHUNK_PAGE_SIZE }),
+			// Mantine's Pagination is 1-based; the API expects a 0-indexed page.
+			client.documents.chunks(doc.id, { page: chunkPage - 1, pageSize: CHUNK_PAGE_SIZE }),
 		retry: false,
 		placeholderData: (prev) => prev,
 		enabled: doc.status === "ready",
@@ -956,6 +959,179 @@ interface UploadItem {
 	error?: string;
 }
 
+// ─── Scope selector (DNF) ───
+
+/**
+ * Builds a DNF scope selector to narrow a document's visibility. Each "set" is a
+ * space-separated list of scope paths that are ANDed together; the sets are ORed.
+ * e.g. set 1 `org/apple` + set 2 `team/x clearance/secret` ⇒
+ * `"org/apple" OR ("team/x" AND "clearance/secret")`. Empty inherits the
+ * uploader's full write region.
+ */
+function ScopeSetsField({
+	value,
+	onChange,
+	disabled,
+}: {
+	value: SpectronScopeSets;
+	onChange: (value: SpectronScopeSets) => void;
+	disabled?: boolean;
+}) {
+	const [draft, setDraft] = useState("");
+
+	const addSet = () => {
+		const paths = Array.from(new Set(draft.trim().split(/\s+/).filter(Boolean)));
+		if (paths.length === 0) return;
+		onChange([...value, paths]);
+		setDraft("");
+	};
+
+	const removeSet = (index: number) => {
+		onChange(value.filter((_, i) => i !== index));
+	};
+
+	const removePath = (setIndex: number, pathIndex: number) => {
+		const next = value
+			.map((set, i) => (i === setIndex ? set.filter((_, j) => j !== pathIndex) : set))
+			.filter((set) => set.length > 0);
+		onChange(next);
+	};
+
+	const expression = value
+		.map((set) =>
+			set.length > 1 ? `(${set.map((p) => `"${p}"`).join(" AND ")})` : `"${set[0]}"`,
+		)
+		.join(" OR ");
+
+	return (
+		<Stack gap="xs">
+			<Box>
+				<Text
+					fz="sm"
+					fw={500}
+					c="bright"
+				>
+					Limit visibility (optional)
+				</Text>
+				<Text
+					fz="xs"
+					c="slate"
+				>
+					Add one or more scope sets to narrow who can see this document. Paths within a
+					set are ANDed; each set is ORed. Leave empty to inherit your full write region.
+				</Text>
+			</Box>
+
+			<Group
+				gap="xs"
+				wrap="nowrap"
+				align="flex-end"
+			>
+				<TextInput
+					flex={1}
+					label="Scope set"
+					placeholder="e.g. team/x clearance/secret"
+					value={draft}
+					disabled={disabled}
+					onChange={(event) => setDraft(event.currentTarget.value)}
+					onKeyDown={(event) => {
+						if (event.key === "Enter") {
+							event.preventDefault();
+							addSet();
+						}
+					}}
+				/>
+				<Button
+					variant="light"
+					onClick={addSet}
+					disabled={disabled || draft.trim().length === 0}
+				>
+					Add set
+				</Button>
+			</Group>
+
+			{value.length > 0 && (
+				<Stack gap={4}>
+					{value.map((set, setIndex) => (
+						<Fragment key={setIndex}>
+							{setIndex > 0 && (
+								<Text
+									fz={11}
+									fw={500}
+									c="slate"
+									ta="center"
+									style={{ letterSpacing: "0.08em" }}
+								>
+									OR
+								</Text>
+							)}
+							<Paper
+								radius="sm"
+								withBorder
+								px="xs"
+								py={4}
+							>
+								<Group
+									gap="xs"
+									wrap="nowrap"
+									align="center"
+								>
+									<Group
+										gap={6}
+										flex={1}
+									>
+										{set.map((path, pathIndex) => (
+											<Badge
+												key={pathIndex}
+												variant="light"
+												color="violet"
+												tt="none"
+												rightSection={
+													disabled ? undefined : (
+														<CloseButton
+															size={14}
+															aria-label={`Remove ${path}`}
+															onClick={() =>
+																removePath(setIndex, pathIndex)
+															}
+														/>
+													)
+												}
+											>
+												{path}
+											</Badge>
+										))}
+									</Group>
+									<Tooltip label="Remove set">
+										<ActionIcon
+											variant="subtle"
+											color="red"
+											size="sm"
+											aria-label={`Remove scope set ${setIndex + 1}`}
+											disabled={disabled}
+											onClick={() => removeSet(setIndex)}
+										>
+											<Icon path={iconTrash} />
+										</ActionIcon>
+									</Tooltip>
+								</Group>
+							</Paper>
+						</Fragment>
+					))}
+					<Text
+						fz="xs"
+						c="slate"
+						ff="monospace"
+						style={{ wordBreak: "break-word" }}
+					>
+						{expression}
+					</Text>
+				</Stack>
+			)}
+		</Stack>
+	);
+}
+
 function UploadModal({
 	client,
 	opened,
@@ -971,11 +1147,13 @@ function UploadModal({
 	const [items, setItems] = useState<UploadItem[]>([]);
 	const [busy, setBusy] = useState(false);
 	const [dragging, setDragging] = useState(false);
+	const [scopes, setScopes] = useState<SpectronScopeSets>([]);
 
 	const reset = () => {
 		setItems([]);
 		setBusy(false);
 		setDragging(false);
+		setScopes([]);
 	};
 
 	const handleClose = () => {
@@ -1008,6 +1186,7 @@ function UploadModal({
 					filename: file.name,
 					title: file.name,
 					contentType: file.type || undefined,
+					scopes: scopes.length > 0 ? scopes : undefined,
 				});
 				update(itemIndex, { state: "done", deduplicated: result.deduplicated });
 				anySucceeded = true;
@@ -1059,6 +1238,12 @@ function UploadModal({
 						handleFiles(event.currentTarget.files);
 						event.currentTarget.value = "";
 					}}
+				/>
+
+				<ScopeSetsField
+					value={scopes}
+					onChange={setScopes}
+					disabled={busy}
 				/>
 
 				<UnstyledButton

--- a/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
@@ -1162,12 +1162,28 @@ function UploadModal({
 		onClose();
 	};
 
-	const runUploads = async (files: File[]) => {
+	// Selecting/dropping files only stages them; the actual upload waits for the
+	// explicit "Upload" action so the user can set scopes first.
+	const stageFiles = (files: File[]) => {
 		if (files.length === 0) return;
+		setItems((prev) => [
+			...prev,
+			...files.map((file): UploadItem => ({ file, state: "pending" })),
+		]);
+	};
 
-		const queued: UploadItem[] = files.map((file) => ({ file, state: "pending" }));
-		const startIndex = items.length;
-		setItems((prev) => [...prev, ...queued]);
+	const removeItem = (index: number) => {
+		setItems((prev) => prev.filter((_, i) => i !== index));
+	};
+
+	const runUploads = async () => {
+		// Upload everything not already uploaded — staged files, plus any that
+		// failed (so the button retries them).
+		const queue = items
+			.map((item, index) => ({ item, index }))
+			.filter(({ item }) => item.state === "pending" || item.state === "failed");
+		if (queue.length === 0) return;
+
 		setBusy(true);
 
 		const update = (index: number, patch: Partial<UploadItem>) => {
@@ -1176,22 +1192,20 @@ function UploadModal({
 
 		let anySucceeded = false;
 
-		for (let i = 0; i < files.length; i++) {
-			const file = files[i];
-			const itemIndex = startIndex + i;
-			update(itemIndex, { state: "uploading" });
+		for (const { item, index } of queue) {
+			update(index, { state: "uploading", error: undefined });
 			try {
 				const result = await client.documents.upload({
-					file,
-					filename: file.name,
-					title: file.name,
-					contentType: file.type || undefined,
+					file: item.file,
+					filename: item.file.name,
+					title: item.file.name,
+					contentType: item.file.type || undefined,
 					scopes: scopes.length > 0 ? scopes : undefined,
 				});
-				update(itemIndex, { state: "done", deduplicated: result.deduplicated });
+				update(index, { state: "done", deduplicated: result.deduplicated });
 				anySucceeded = true;
 			} catch (err) {
-				update(itemIndex, {
+				update(index, {
 					state: "failed",
 					error: err instanceof Error ? err.message : String(err),
 				});
@@ -1211,14 +1225,18 @@ function UploadModal({
 
 	const handleFiles = (fileList: FileList | null) => {
 		if (!fileList) return;
-		runUploads(Array.from(fileList));
+		stageFiles(Array.from(fileList));
 	};
 
 	const onDrop = (event: React.DragEvent) => {
 		event.preventDefault();
 		setDragging(false);
-		runUploads(Array.from(event.dataTransfer.files));
+		stageFiles(Array.from(event.dataTransfer.files));
 	};
+
+	const pendingCount = items.filter(
+		(item) => item.state === "pending" || item.state === "failed",
+	).length;
 
 	return (
 		<Drawer
@@ -1238,12 +1256,6 @@ function UploadModal({
 						handleFiles(event.currentTarget.files);
 						event.currentTarget.value = "";
 					}}
-				/>
-
-				<ScopeSetsField
-					value={scopes}
-					onChange={setScopes}
-					disabled={busy}
 				/>
 
 				<UnstyledButton
@@ -1295,10 +1307,21 @@ function UploadModal({
 							<UploadRow
 								key={`${item.file.name}-${index}`}
 								item={item}
+								onRemove={
+									busy || item.state === "uploading" || item.state === "done"
+										? undefined
+										: () => removeItem(index)
+								}
 							/>
 						))}
 					</Stack>
 				)}
+
+				<ScopeSetsField
+					value={scopes}
+					onChange={setScopes}
+					disabled={busy}
+				/>
 
 				<Group justify="flex-end">
 					<Button
@@ -1310,12 +1333,22 @@ function UploadModal({
 						{items.some((item) => item.state === "done") ? "Done" : "Cancel"}
 					</Button>
 					<Button
-						variant="gradient"
+						variant="default"
 						leftSection={<Icon path={iconUpload} />}
 						onClick={() => inputRef.current?.click()}
-						loading={busy}
+						disabled={busy}
 					>
-						Choose files
+						Add files
+					</Button>
+					<Button
+						variant="gradient"
+						onClick={runUploads}
+						loading={busy}
+						disabled={pendingCount === 0}
+					>
+						{pendingCount > 0
+							? `Upload ${pendingCount} file${pendingCount === 1 ? "" : "s"}`
+							: "Upload"}
 					</Button>
 				</Group>
 			</Stack>
@@ -1323,7 +1356,7 @@ function UploadModal({
 	);
 }
 
-function UploadRow({ item }: { item: UploadItem }) {
+function UploadRow({ item, onRemove }: { item: UploadItem; onRemove?: () => void }) {
 	return (
 		<Paper
 			p="xs"
@@ -1358,6 +1391,13 @@ function UploadRow({ item }: { item: UploadItem }) {
 					</Text>
 				</Box>
 				<UploadStatus item={item} />
+				{onRemove && (
+					<CloseButton
+						size="sm"
+						aria-label={`Remove ${item.file.name}`}
+						onClick={onRemove}
+					/>
+				)}
 			</Group>
 		</Paper>
 	);

--- a/src/screens/surrealist/pages/Context/views/ScopesView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/ScopesView/index.tsx
@@ -245,7 +245,7 @@ function ScopeManager({ client }: { client: Spectron }) {
 			if (error instanceof ScopeError) {
 				showErrorNotification({
 					title: "Permission required",
-					content: new Error("You need the delete_scope grant to tombstone scopes here."),
+					content: new Error("You need the scope:delete grant to tombstone scopes here."),
 				});
 			} else {
 				showErrorNotification({
@@ -623,7 +623,7 @@ function RegisterModal({
 						variant="light"
 						title="Permission required"
 					>
-						You need the create_scope grant to register scopes here.
+						You need the scope:create grant to register scopes here.
 					</Alert>
 				)}
 

--- a/src/screens/surrealist/pages/Context/views/SettingsView/tabs/Principals.tsx
+++ b/src/screens/surrealist/pages/Context/views/SettingsView/tabs/Principals.tsx
@@ -78,13 +78,13 @@ const SEP = " / ";
 type OwnerKind = "human" | "service";
 
 const VERB_HELP: Record<SpectronVerb, string> = {
-	read: "Read facts in the granted scopes",
-	write: "Create and supersede facts in the granted scopes",
-	create_scope: "Register new scope nodes",
-	delete_scope: "Tombstone scope nodes",
-	grant: "Share access with other principals",
-	manage: "Manage principals, keys, and configuration",
-	forget: "Permanently erase facts (GDPR)",
+	"memory:read": "Read facts and documents in the granted scopes",
+	"memory:write": "Create and supersede facts, and ingest documents, in the granted scopes",
+	"memory:forget": "Permanently erase facts and documents (GDPR)",
+	"scope:read": "Browse the scope vocabulary and node metadata",
+	"scope:create": "Register new scope nodes",
+	"scope:delete": "Tombstone scope nodes",
+	"grant:manage": "List, grant, and revoke access on principals",
 };
 
 // ─── Grant helpers ───

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -802,24 +802,24 @@ export interface MintSpectronAccessToken {
 	ttl_seconds?: number;
 }
 
-/** The seven Spectron grant verbs (design-scope-model §6.1). */
+/** The seven Spectron grant verbs in `<noun>:<verb>` form (design-scope-model §6.1). */
 export type SpectronVerb =
-	| "read"
-	| "write"
-	| "create_scope"
-	| "delete_scope"
-	| "grant"
-	| "manage"
-	| "forget";
+	| "memory:read"
+	| "memory:write"
+	| "memory:forget"
+	| "scope:read"
+	| "scope:create"
+	| "scope:delete"
+	| "grant:manage";
 
 export const SPECTRON_VERBS: SpectronVerb[] = [
-	"read",
-	"write",
-	"create_scope",
-	"delete_scope",
-	"grant",
-	"manage",
-	"forget",
+	"memory:read",
+	"memory:write",
+	"memory:forget",
+	"scope:read",
+	"scope:create",
+	"scope:delete",
+	"grant:manage",
 ];
 
 /** Identity kind for a principal (design-scope-model §5.2). */
@@ -827,6 +827,15 @@ export type SpectronPrincipalKind = "human" | "agent" | "service" | "unknown";
 
 /** Per-verb scope-pattern map carried by a principal or key. */
 export type SpectronGrants = Partial<Record<SpectronVerb, string[]>>;
+
+/**
+ * A DNF scope selector for tagging writes (documents, facts, sessions): an OR of
+ * conjunctive clauses. Each inner array is a set of scope paths that are ANDed;
+ * the outer array ORs the clauses. E.g. `[["team/a"], ["team/b", "clearance/secret"]]`
+ * means `team/a OR (team/b AND clearance/secret)`. Empty inherits the caller's full
+ * write region. Mirrors the SDK `ScopeSets` wire type.
+ */
+export type SpectronScopeSets = string[][];
 
 export interface SpectronPrincipal {
 	id: string;


### PR DESCRIPTION
## What & why

A batch of Spectron context UI changes, plus the SDK bump that unblocks the headline feature.

### Scoped document uploads (new)
The upload dialog now has an optional **scope selector** so a user can tag a document with a region narrower than their own access (e.g. you hold `org/apple/*` but upload as `org/apple/product/macbook`).

- Full **DNF** model: each "set" is a space-separated list of paths that are **ANDed**; sets are **ORed**. Rendered as compact chip rows joined by `OR`, with a live `"a/b" OR ("c/d" AND "e/f")` summary.
- Added the `SpectronScopeSets` wire type; scopes flow through the typed `documents.upload({ …, scopes })`. Empty ⇒ inherits the uploader's full write region. Each clause must sit within the caller's `memory:write` region, so it can only narrow.
- **Staged upload flow:** selecting/dropping a file now *stages* it (with a remove control) instead of uploading instantly; an explicit **Upload** button commits the batch, so scopes can be set first. Dialog order is dropzone → staged files → scope selector → upload.

### Grant verb format
Renamed the Spectron grant verbs to the namespaced `<noun>:<verb>` form — `memory:read`, `memory:write`, `memory:forget`, `scope:read`, `scope:create`, `scope:delete`, `grant:manage` — replacing the stale flat names. These keys go on the wire to cloud-api, so this is a correctness fix, not just labels. Touches the type/const, the principal grant help text, and two `ScopesView` permission-error strings.

### Pagination fix
The documents list and chunk inspector now send a **0-indexed** `page` to the API (the API is 0-indexed; Mantine's `Pagination` is 1-based), so the first page no longer skips to the second.

### SDK bump
`@surrealdb/spectron` `1.0.0-alpha.1` → `1.0.0-alpha.2`, which adds `scopes` to `DocumentUploadOptions`. This replaced an interim `Transport`-based upload workaround — the upload is now a single typed SDK call.

## Reviewer notes
- `provider.tsx` is unchanged in the final diff (a `token` exposure added for the interim workaround was reverted once the typed path landed).
- alpha.2's internal `Verb` type still documents the old verb names — irrelevant here, since surrealist owns its `SpectronVerb` type and grants are enforced in cloud-api.
- The DNF **server** rollout is what fully activates scoped uploads end-to-end; against an older server the `scopes` field is silently ignored (not an error).

## Verification
- `bun run qts` (`tsc --noEmit`) — passes, no errors.
- `biome check` on the touched files — clean.
- Live preview not exercised: the flow needs Auth0 login + a provisioned context with a live Spectron backend.