### PR TITLE
Bump @surrealdb/spectron to alpha.4 and display API key grants

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,7 @@
         "@surrealdb/lezer": "1.0.3",
         "@surrealdb/ql-wasm-2": "npm:@surrealdb/ql-wasm@0.2.0-beta.11",
         "@surrealdb/ql-wasm-3": "npm:@surrealdb/ql-wasm@0.3.1",
-        "@surrealdb/spectron": "1.0.0-alpha.3",
+        "@surrealdb/spectron": "1.0.0-alpha.4",
         "@surrealdb/surql-fmt": "^0.1.0-beta.2",
         "@surrealdb/ui": "^1.2.3",
         "@surrealdb/wasm": "^3.0.3",
@@ -525,7 +525,7 @@
 
     "@surrealdb/ql-wasm-3": ["@surrealdb/ql-wasm@0.3.1", "", {}, "sha512-0fRDqhibbbzSrSIw4ertFsN7xgOI8nBx0CipDnMeCYN8Vb9Sc5/ZMahpS2ZTQt1po+k1TmayjlH5CHtx41Iegw=="],
 
-    "@surrealdb/spectron": ["@surrealdb/spectron@1.0.0-alpha.3", "", { "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" } }, "sha512-p6W2Jbd/iBd7GJttqmIhyfeoIRrPmw+twh41VTz5KiTVbFP3QJHNb8J6/rPho7aFmkmrgN+D70JHKLOFt65Pyw=="],
+    "@surrealdb/spectron": ["@surrealdb/spectron@1.0.0-alpha.4", "", { "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" } }, "sha512-2X9nmZ2YnIeM8ZuZRCjODkqEmPw3GOfsb3lNKplji3kr2UlxNSWNKwXE/av20H7t64KFjvHnWB6ZR4Z1PruQDw=="],
 
     "@surrealdb/surql-fmt": ["@surrealdb/surql-fmt@0.1.0-beta.2", "", { "dependencies": { "@lezer/common": "^1.5.1", "@surrealdb/lezer": "^1.0.4" }, "peerDependencies": { "typescript": "^5.9.3" }, "bin": { "surqlfmt": "dist/surql-fmt-cli.js" } }, "sha512-uibW3TucV9/P99LtAOpBPnDiN4joPqlCiLEUpK7EOWrrH2T2jWg6uPMI1JlgVun65lBmi4xloxvdeMMNxa2uKA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "surrealist",
@@ -46,7 +45,7 @@
         "@surrealdb/lezer": "1.0.3",
         "@surrealdb/ql-wasm-2": "npm:@surrealdb/ql-wasm@0.2.0-beta.11",
         "@surrealdb/ql-wasm-3": "npm:@surrealdb/ql-wasm@0.3.1",
-        "@surrealdb/spectron": "1.0.0-alpha.2",
+        "@surrealdb/spectron": "1.0.0-alpha.3",
         "@surrealdb/surql-fmt": "^0.1.0-beta.2",
         "@surrealdb/ui": "^1.2.3",
         "@surrealdb/wasm": "^3.0.3",
@@ -526,7 +525,7 @@
 
     "@surrealdb/ql-wasm-3": ["@surrealdb/ql-wasm@0.3.1", "", {}, "sha512-0fRDqhibbbzSrSIw4ertFsN7xgOI8nBx0CipDnMeCYN8Vb9Sc5/ZMahpS2ZTQt1po+k1TmayjlH5CHtx41Iegw=="],
 
-    "@surrealdb/spectron": ["@surrealdb/spectron@1.0.0-alpha.2", "", { "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" } }, "sha512-oSmsfXy/zUOoH3nHVPMSJpKE9hK2nZstlRKNyv1IY+w8v4fLTine2SBC6UcJMIYR/FyLXqMtUseO7/7dSxOH2A=="],
+    "@surrealdb/spectron": ["@surrealdb/spectron@1.0.0-alpha.3", "", { "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" } }, "sha512-p6W2Jbd/iBd7GJttqmIhyfeoIRrPmw+twh41VTz5KiTVbFP3QJHNb8J6/rPho7aFmkmrgN+D70JHKLOFt65Pyw=="],
 
     "@surrealdb/surql-fmt": ["@surrealdb/surql-fmt@0.1.0-beta.2", "", { "dependencies": { "@lezer/common": "^1.5.1", "@surrealdb/lezer": "^1.0.4" }, "peerDependencies": { "typescript": "^5.9.3" }, "bin": { "surqlfmt": "dist/surql-fmt-cli.js" } }, "sha512-uibW3TucV9/P99LtAOpBPnDiN4joPqlCiLEUpK7EOWrrH2T2jWg6uPMI1JlgVun65lBmi4xloxvdeMMNxa2uKA=="],
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"@surrealdb/lezer": "1.0.3",
 		"@surrealdb/ql-wasm-2": "npm:@surrealdb/ql-wasm@0.2.0-beta.11",
 		"@surrealdb/ql-wasm-3": "npm:@surrealdb/ql-wasm@0.3.1",
-		"@surrealdb/spectron": "1.0.0-alpha.3",
+		"@surrealdb/spectron": "1.0.0-alpha.4",
 		"@surrealdb/surql-fmt": "^0.1.0-beta.2",
 		"@surrealdb/ui": "^1.2.3",
 		"@surrealdb/wasm": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"@surrealdb/lezer": "1.0.3",
 		"@surrealdb/ql-wasm-2": "npm:@surrealdb/ql-wasm@0.2.0-beta.11",
 		"@surrealdb/ql-wasm-3": "npm:@surrealdb/ql-wasm@0.3.1",
-		"@surrealdb/spectron": "1.0.0-alpha.2",
+		"@surrealdb/spectron": "1.0.0-alpha.3",
 		"@surrealdb/surql-fmt": "^0.1.0-beta.2",
 		"@surrealdb/ui": "^1.2.3",
 		"@surrealdb/wasm": "^3.0.3",

--- a/src/screens/surrealist/pages/Context/views/ApiKeysView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/ApiKeysView/index.tsx
@@ -1,6 +1,7 @@
 import {
 	ActionIcon,
 	Alert,
+	Badge,
 	Box,
 	Button,
 	Collapse,
@@ -290,22 +291,30 @@ export default function ApiKeysView({ context }: ContextViewProps) {
 											<Group
 												gap="sm"
 												wrap="nowrap"
+												align="flex-start"
 											>
 												<ThemeIcon
 													size={28}
 													radius="md"
 													variant="light"
 													color="violet"
+													mt={2}
 												>
 													<Icon path={iconKey} />
 												</ThemeIcon>
-												<Text
-													fw={500}
-													c="bright"
-													className="selectable"
+												<Stack
+													gap={6}
+													miw={0}
 												>
-													{apiKey.name}
-												</Text>
+													<Text
+														fw={500}
+														c="bright"
+														className="selectable"
+													>
+														{apiKey.name}
+													</Text>
+													<KeyGrants grants={apiKey.grants} />
+												</Stack>
 											</Group>
 										</Table.Td>
 										<Table.Td w={0}>
@@ -583,6 +592,61 @@ export default function ApiKeysView({ context }: ContextViewProps) {
 					</Group>
 				</Stack>
 			</Modal>
+		</Stack>
+	);
+}
+
+/**
+ * Renders a key's attenuating grants as a per-verb scope-pattern summary. Empty
+ * or absent grants mean the key inherits the principal's full access.
+ */
+function KeyGrants({ grants }: { grants?: SpectronGrants }) {
+	const summary = SPECTRON_VERBS.map((verb) => ({
+		verb,
+		patterns: grants?.[verb] ?? [],
+	})).filter((entry) => entry.patterns.length > 0);
+
+	if (summary.length === 0) {
+		return (
+			<Text
+				fz="xs"
+				c="slate"
+			>
+				Inherits your full access
+			</Text>
+		);
+	}
+
+	return (
+		<Stack gap={4}>
+			{summary.map(({ verb, patterns }) => (
+				<Group
+					key={verb}
+					gap={6}
+					wrap="nowrap"
+					align="center"
+				>
+					<Badge
+						variant="light"
+						color="violet"
+						size="sm"
+						tt="none"
+						ff="monospace"
+						style={{ flexShrink: 0 }}
+					>
+						{verb}
+					</Badge>
+					<Text
+						fz="xs"
+						c="slate"
+						ff="monospace"
+						className="selectable"
+						style={{ wordBreak: "break-all" }}
+					>
+						{patterns.join("  ·  ")}
+					</Text>
+				</Group>
+			))}
 		</Stack>
 	);
 }

--- a/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
@@ -493,17 +493,6 @@ function DocumentCard({ document: doc, onInspect, onDelete, deleting }: Document
 								{formatFileSize(doc.sizeBytes)}
 							</Text>
 						</Group>
-						{doc.status === "ready" && (
-							<Text
-								fz="xs"
-								c="slate"
-								mt={4}
-							>
-								{(doc.chunkCount ?? 0).toLocaleString()} chunks
-								{doc.keywordCount != null &&
-									` · ${doc.keywordCount.toLocaleString()} keywords`}
-							</Text>
-						)}
 						<Text
 							fz="xs"
 							c="slate"
@@ -780,19 +769,9 @@ function InspectorBody({
 					label="Size"
 					value={formatFileSize(doc.sizeBytes)}
 				/>
-				{doc.language && (
-					<MetaRow
-						label="Language"
-						value={doc.language}
-					/>
-				)}
 				<MetaRow
 					label="Chunks"
-					value={(doc.chunkCount ?? 0).toLocaleString()}
-				/>
-				<MetaRow
-					label="Keywords"
-					value={(doc.keywordCount ?? 0).toLocaleString()}
+					value={chunksQuery.data ? chunksQuery.data.total.toLocaleString() : "—"}
 				/>
 				<MetaRow
 					label="Created"

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -789,6 +789,12 @@ export interface ContextApiKey {
 	spectron_context_id: string;
 	name: string;
 	key?: string;
+	/**
+	 * The key's attenuating grants (per-verb scope patterns). Absent/empty means
+	 * the key inherits the principal's full access. Only present on the list
+	 * response once the API surfaces it.
+	 */
+	grants?: SpectronGrants;
 }
 
 /**


### PR DESCRIPTION
## What & why

### Bump `@surrealdb/spectron` to `1.0.0-alpha.4`
Picks up the latest Spectron API.

- **alpha.3 (breaking, for documents):** `DocumentJson` no longer carries `chunkCount`, `keywordCount`, or `language`. Adapted the UI:
  - Document card: dropped the `"N chunks · N keywords"` stat line (no per-card source for it).
  - Inspector drawer: removed the **Language** and **Keywords** rows; re-sourced the **Chunks** count from the already-fetched chunks query (`chunksQuery.data.total`), so it survives (shows `—` until loaded).
- **alpha.4 (fix):** the document list/chunk query params were sent snake_case (`page_size`, `mime_type`) while the OpenAPI had moved to camelCase (`pageSize`, `mimeType`), so paging size was silently ignored by the server. alpha.4 fixes the SDK's wire mapping — no surrealist change needed, but it means pagination now actually applies.

The remaining alpha.3/alpha.4 changes were additive/cosmetic for surrealist (new self-service `/keys` + `/me` OpenAPI paths; verb docs renamed to the namespaced form, which surrealist already uses). The exported type surface is identical between alpha.3 and alpha.4.

### Display API key grants
`ApiKeysView` now shows each key's attenuating grants under its name — a per-verb scope-pattern summary (`KeyGrants`), or *"Inherits your full access"* when unattenuated. Adds an optional `grants?: SpectronGrants` to `ContextApiKey`.

Note: the keys list comes from cloud-api's `/api_keys` (`ContextApiKey`), not the SDK, so the grants display lights up once cloud-api surfaces `grants` on that response (enabled by spectron [#715](https://github.com/surrealdb/spectron/pull/715) + the cloud-api side). The field is optional, so it's inert and safe until then.

## Verification
- `bun run qts` (`tsc --noEmit`) — passes.
- `biome check` on the changed files — clean.
- Live preview not exercised: the views need Auth0 + a provisioned context with a live Spectron backend.

Branched off latest `main` (after #1239 and #1237).