### PR TITLE
Update context connection snippets to the DNF scopes format

### DIFF
--- a/src/screens/surrealist/pages/Context/views/IntegrationView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/index.tsx
@@ -103,7 +103,7 @@ client = Spectron(
 					"Open a session scoped to a user and record conversation turns. Spectron extracts entities, attributes, and relations on every turn so the memory graph grows automatically.",
 				code: `from surrealdb import SpectronTurnRole
 
-session = client.sessions.create(scope={"user": "alex"})
+session = client.sessions.create(scopes=["user/alex"])
 session.turn(SpectronTurnRole.USER, "Hi, I'm Alex. I prefer dark mode.")
 session.turn(SpectronTurnRole.ASSISTANT, "Got it, Alex — noted.")`,
 				lang: "python",
@@ -153,7 +153,7 @@ const client = new Spectron({
 				code: `import { TurnRole } from "@surrealdb/spectron";
 
 const session = await client.sessions.create({
-    scope: { user: "alex" },
+    scopes: ["user/alex"],
 });
 
 await session.turn({ role: TurnRole.user, content: "Hi, I'm Alex. I prefer dark mode." });
@@ -190,7 +190,7 @@ await session.turn({ role: TurnRole.assistant, content: "Got it, Alex — noted.
 				code: `curl -X POST ${restRoot}/sessions \\
     -H "API-KEY: your-api-key" \\
     -H "Content-Type: application/json" \\
-    -d '{"scope":["user/alex"]}'`,
+    -d '{"scopes":["user/alex"]}'`,
 				lang: "bash",
 			},
 			{

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/langchain.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/langchain.tsx
@@ -30,7 +30,7 @@ from spectron_langchain import SpectronMemory
 memory = SpectronMemory(
     api_key="your-api-key",
     endpoint="${endpoint}",
-    scope={"user": "alex", "org": "acme"},
+    scopes=[["user/alex", "org/acme"]],
 )
 
 chain = ConversationChain(
@@ -54,7 +54,7 @@ llm = ChatOpenAI(model="gpt-4o")
 memory = SpectronMemory(
     api_key="your-api-key",
     endpoint="${endpoint}",
-    scope={"user": "alex", "org": "acme"},
+    scopes=[["user/alex", "org/acme"]],
 )
 retriever = SpectronRetriever(
     api_key="your-api-key",

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/n8n.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/n8n.tsx
@@ -15,14 +15,14 @@ export function buildN8nSteps(context: CloudContext): IntegrationStep[] {
 		{
 			title: "Open a session (HTTP Request)",
 			description:
-				"Use an HTTP Request node against this context’s REST root. POST JSON with a scope array; store the session id from the response for later nodes.",
+				"Use an HTTP Request node against this context’s REST root. POST JSON with a scopes array; store the session id from the response for later nodes.",
 			code: `POST ${restRoot}/sessions
 Headers:
   API-KEY: {{ $env.SPECTRON_API_KEY }}
   Content-Type: application/json
 Body:
 {
-  "scope": ["user/{{ $json.userId }}"]
+  "scopes": ["user/{{ $json.userId }}"]
 }`,
 			lang: "text",
 		},

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/openai-agents.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/openai-agents.tsx
@@ -35,11 +35,11 @@ memory = Spectron(
 )
 
 async def main() -> None:
-    session = await memory.sessions.create(scope={"user": "alex"})
+    session = await memory.sessions.create(scopes=["user/alex"])
     ctx = await memory.context(
         query="What should the assistant know about this user?",
         k=10,
-        scope=session.scope,
+        scopes=session.scopes,
     )
     agent = Agent(
         name="Assistant",

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/vercel-ai.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/vercel-ai.tsx
@@ -39,7 +39,7 @@ const spectron = createSpectron({
 			code: `import { openai } from "@ai-sdk/openai";
 
 const session = await spectron.createSession({
-    scope: { org: "acme", agent: "web-assistant", user: "alex" },
+    scopes: [["org/acme", "agent/web-assistant", "user/alex"]],
 });
 
 const result = await session.streamText({


### PR DESCRIPTION
## What & why

The Spectron API replaced the singular `scope` dictionary with a plural **`scopes`** DNF selector: an array of scope-path strings (OR of clauses), or an array of arrays (each inner array is ANDed). The "connect to a context" integration snippets still showed the old dictionary form (`scope: { user: "alex" }`), which no longer matches the API. This updates them all.

### Changes (snippet examples only — no runtime code)
| Snippet | Before | After |
|---|---|---|
| Native Python | `scope={"user": "alex"}` | `scopes=["user/alex"]` |
| Native JavaScript | `scope: { user: "alex" }` | `scopes: ["user/alex"]` |
| REST (curl) | `"scope":["user/alex"]` | `"scopes":["user/alex"]` |
| LangChain ×2 | `scope={"user": "alex", "org": "acme"}` | `scopes=[["user/alex", "org/acme"]]` |
| OpenAI Agents | `scope={"user": "alex"}` / `scope=session.scope` | `scopes=["user/alex"]` / `scopes=session.scopes` |
| n8n (REST body) | `"scope": ["user/…"]` | `"scopes": ["user/…"]` |
| Vercel AI | `scope: { org, agent, user }` | `scopes: [["org/acme", "agent/web-assistant", "user/alex"]]` |

- Single-scope examples use the simple array-of-strings form.
- Multi-dimension examples use the nested array-of-arrays form, preserving the original dictionaries' AND semantics and demonstrating both accepted shapes.
- Renamed singular `scope` → plural `scopes` throughout (including `session.scope` → `session.scopes` and the n8n description).

Scoped to the `scopes` format as requested; left the recall snippets (`client.query(...)`) untouched (separate API surface).

## Verification
- `bun run qts` (`tsc --noEmit`) — passes.
- `biome check` on the IntegrationView files — clean.

Branched off latest `main`; independent of the alpha.4 bump in #1241.