### PR TITLE
Address Spectron frontend feedback from June 2026 testing round

### DIFF
--- a/src/components/Sidekick/chat/index.tsx
+++ b/src/components/Sidekick/chat/index.tsx
@@ -17,7 +17,6 @@ import { Icon, iconChevronRight, iconCursor, iconOpen, pictoSidekickGradient } f
 import { shuffle } from "radash";
 import { useEffect, useMemo, useRef } from "react";
 import { adapter } from "~/adapter";
-import glowImg from "~/assets/images/radial-glow.png";
 import { useStable } from "~/hooks/stable";
 import { useIsLight } from "~/hooks/theme";
 import { useAuthentication } from "~/providers/Auth";
@@ -113,16 +112,6 @@ export function SidekickChat({ isAuthed, padding, stream }: ChatConversationProp
 						gap={0}
 					>
 						<Box pos="relative">
-							<Image
-								pos="absolute"
-								src={glowImg}
-								inset={0}
-								opacity={0.5}
-								style={{
-									transform: "scale(2.5)",
-									transition: "opacity 0.3s ease",
-								}}
-							/>
 							<Image
 								pos="relative"
 								src={pictoSidekickGradient}

--- a/src/components/Sidekick/index.tsx
+++ b/src/components/Sidekick/index.tsx
@@ -99,16 +99,6 @@ export const Sidekick = forwardRef<SidekickHandle, SidekickProps>(
 						>
 							<Box pos="relative">
 								<Image
-									pos="absolute"
-									src={glowImg}
-									inset={0}
-									opacity={0.3}
-									style={{
-										transform: "scale(2.25)",
-										transition: "opacity 0.3s ease",
-									}}
-								/>
-								<Image
 									pos="relative"
 									src={pictoSidekickGradient}
 									w={36}

--- a/src/modals/onboarding.tsx
+++ b/src/modals/onboarding.tsx
@@ -241,7 +241,7 @@ export function ContextsOnboarding({ deployHref }: ContextsOnboardingProps) {
 		>
 			<List.Item>Automatically extract memories and facts from conversations</List.Item>
 			<List.Item>Hybrid retrieval combining graph traversal and vector similarity</List.Item>
-			<List.Item>Temporal awareness with bi-temporal, append-only facts</List.Item>
+			<List.Item>Temporal awareness with tri-temporal, append-only facts</List.Item>
 			<List.Item>Multi-agent shared memory with full ACID transactions</List.Item>
 		</OnboardingModal>
 	);

--- a/src/screens/surrealist/pages/Context/utils/scope-validation.ts
+++ b/src/screens/surrealist/pages/Context/utils/scope-validation.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared validation for Spectron scope paths, used by the Scopes view and the
+ * document upload form so both agree on what a well-formed scope path is.
+ */
+
+/** A single slash-separated segment: lowercase, no spaces, starts alphanumeric. */
+export const SCOPE_SEGMENT = /^[a-z0-9][a-z0-9._-]*$/;
+
+/**
+ * Validates a slash-separated scope path: lowercase segments, no spaces, no
+ * `=` or `*`, and no empty segments. Returns an error string, or `null` when
+ * the path is acceptable.
+ */
+export function validateScopePath(raw: string): string | null {
+	const value = raw.trim();
+	if (!value) {
+		return "Enter a scope path";
+	}
+	if (/\s/.test(value)) {
+		return "Paths cannot contain spaces";
+	}
+	if (value.includes("=") || value.includes("*")) {
+		return "Paths cannot contain '=' or '*'";
+	}
+
+	const segments = value.replace(/\/+$/, "").split("/");
+	if (segments.some((s) => s.length === 0)) {
+		return "Paths cannot contain empty segments";
+	}
+	if (!segments.every((s) => SCOPE_SEGMENT.test(s))) {
+		return "Use lowercase segments like org/apple/product";
+	}
+	return null;
+}
+
+/** Strips the canonical trailing slash from a registered scope path. */
+export function normalizeScopePath(path: string): string {
+	return path.replace(/\/+$/, "");
+}

--- a/src/screens/surrealist/pages/Context/views/ApiKeysView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/ApiKeysView/index.tsx
@@ -37,7 +37,8 @@ import {
 	iconTrash,
 	pictoKeyGradient,
 } from "@surrealdb/ui";
-import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
 import { Link } from "wouter";
 import {
 	useDeleteContextApiKeyMutation,
@@ -55,6 +56,7 @@ import { ON_FOCUS_SELECT, showErrorNotification, showInfo } from "~/util/helpers
 import { ContextHero } from "../../components/ContextHero";
 import { useSpectron } from "../../provider";
 import type { ContextViewProps } from "../../types";
+import { normalizeScopePath } from "../../utils/scope-validation";
 import classes from "./style.module.scss";
 
 type IntegrationTab = "javascript" | "python" | "api";
@@ -90,7 +92,7 @@ const INTEGRATION_QUICK_LINKS: IntegrationQuickLink[] = [
 
 export default function ApiKeysView({ context }: ContextViewProps) {
 	const organization = context.organization_id;
-	const { principalId } = useSpectron();
+	const { client, principalId } = useSpectron();
 	const { data: apiKeys } = useCloudContextApiKeysQuery(organization, context.id);
 	const mintKeyMutation = useMintScopedKeyMutation(organization, context.id);
 	const deleteKeyMutation = useDeleteContextApiKeyMutation(organization, context.id);
@@ -109,6 +111,27 @@ export default function ApiKeysView({ context }: ContextViewProps) {
 		return seeded;
 	});
 	const [createdKey, setCreatedKey] = useState<ContextApiKey | null>(null);
+
+	// Registered scopes power autocomplete for the per-verb grant patterns. Only
+	// fetched while the create modal is open. (Shares the cache key used by the
+	// Scopes and Documents views.)
+	const scopesQuery = useQuery({
+		queryKey: ["spectron", context.id, "scopes", "list"],
+		enabled: !!client && modalOpened,
+		retry: false,
+		queryFn: async () => {
+			if (!client) {
+				throw new Error("Spectron client is not ready");
+			}
+			return client.scopes.list();
+		},
+	});
+
+	const availableScopes = useMemo(
+		() =>
+			(scopesQuery.data ?? []).map((scope) => normalizeScopePath(scope.path)).filter(Boolean),
+		[scopesQuery.data],
+	);
 
 	const resetCreateForm = () => {
 		setNewKeyName("");
@@ -551,6 +574,7 @@ export default function ApiKeysView({ context }: ContextViewProps) {
 										<TagsInput
 											flex={1}
 											placeholder="Add scope pattern…"
+											data={availableScopes}
 											value={grantDraft[verb]}
 											onChange={(value) =>
 												setGrantDraft((prev) => ({

--- a/src/screens/surrealist/pages/Context/views/DashboardView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/DashboardView/index.tsx
@@ -135,7 +135,7 @@ export default function DashboardView({ context }: ContextViewProps) {
 					What's in this context
 				</SectionTitle>
 				<Box mt="xl">
-					<OverviewStats />
+					<OverviewStats onNavigate={goToPage} />
 				</Box>
 			</Box>
 
@@ -246,7 +246,7 @@ function CopyableDetail({ label, value }: { label: string; value: string }) {
 
 // ─── At-a-glance stats (SDK-powered) ───
 
-function OverviewStats() {
+function OverviewStats({ onNavigate }: { onNavigate: (page: ContextViewPage) => void }) {
 	const { client, status } = useSpectron();
 
 	if (status !== "ready" || !client) {
@@ -277,6 +277,8 @@ function OverviewStats() {
 				queryKey="documents"
 				client={client}
 				resolve={async (c) => (await c.documents.list({ pageSize: 1 })).total}
+				navigateTo="documents"
+				onNavigate={onNavigate}
 			/>
 			<StatCard
 				icon={iconMemory}
@@ -291,6 +293,8 @@ function OverviewStats() {
 						(state.context?.entities?.length ?? 0)
 					);
 				}}
+				navigateTo="memory"
+				onNavigate={onNavigate}
 			/>
 			<StatCard
 				icon={iconFolderSecure}
@@ -301,6 +305,8 @@ function OverviewStats() {
 					const scopes = await c.scopes.list();
 					return Array.isArray(scopes) ? scopes.length : 0;
 				}}
+				navigateTo="scopes"
+				onNavigate={onNavigate}
 			/>
 			<StatCard
 				icon={iconHistory}
@@ -308,6 +314,8 @@ function OverviewStats() {
 				queryKey="queries"
 				client={client}
 				resolve={async (c) => (await c.traces.stats()).totalQueries}
+				navigateTo="memory"
+				onNavigate={onNavigate}
 			/>
 		</SimpleGrid>
 	);
@@ -319,9 +327,19 @@ interface StatCardProps {
 	queryKey: string;
 	client: Spectron;
 	resolve: (client: Spectron) => Promise<number>;
+	navigateTo: ContextViewPage;
+	onNavigate: (page: ContextViewPage) => void;
 }
 
-function StatCard({ icon, label, queryKey, client, resolve }: StatCardProps) {
+function StatCard({
+	icon,
+	label,
+	queryKey,
+	client,
+	resolve,
+	navigateTo,
+	onNavigate,
+}: StatCardProps) {
 	const query = useQuery({
 		queryKey: ["spectron", client.contextId, "overview-stat", queryKey],
 		queryFn: () => resolve(client),
@@ -330,48 +348,55 @@ function StatCard({ icon, label, queryKey, client, resolve }: StatCardProps) {
 	});
 
 	return (
-		<Paper
-			p="md"
-			radius="md"
+		<UnstyledButton
+			onClick={() => onNavigate(navigateTo)}
+			w="100%"
+			style={{ cursor: "pointer" }}
+			aria-label={`View ${label}`}
 		>
-			<Group
-				gap="sm"
-				wrap="nowrap"
+			<Paper
+				p="md"
+				radius="md"
 			>
-				<ThemeIcon
-					size={36}
-					radius="md"
-					variant="light"
-					color="violet"
+				<Group
+					gap="sm"
+					wrap="nowrap"
 				>
-					<Icon path={icon} />
-				</ThemeIcon>
-				<Box>
-					{query.isPending ? (
-						<Skeleton
-							h={24}
-							w={48}
-							mb={4}
-						/>
-					) : (
-						<Text
-							fz={24}
-							fw={700}
-							c="bright"
-							lh={1.1}
-						>
-							{query.isError ? "—" : (query.data ?? 0).toLocaleString()}
-						</Text>
-					)}
-					<Text
-						fz="xs"
-						c="slate"
+					<ThemeIcon
+						size={36}
+						radius="md"
+						variant="light"
+						color="violet"
 					>
-						{label}
-					</Text>
-				</Box>
-			</Group>
-		</Paper>
+						<Icon path={icon} />
+					</ThemeIcon>
+					<Box>
+						{query.isPending ? (
+							<Skeleton
+								h={24}
+								w={48}
+								mb={4}
+							/>
+						) : (
+							<Text
+								fz={24}
+								fw={700}
+								c="bright"
+								lh={1.1}
+							>
+								{query.isError ? "—" : (query.data ?? 0).toLocaleString()}
+							</Text>
+						)}
+						<Text
+							fz="xs"
+							c="slate"
+						>
+							{label}
+						</Text>
+					</Box>
+				</Group>
+			</Paper>
+		</UnstyledButton>
 	);
 }
 

--- a/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
@@ -1,5 +1,7 @@
 import {
 	ActionIcon,
+	Alert,
+	Autocomplete,
 	Badge,
 	Box,
 	Button,
@@ -26,21 +28,24 @@ import {
 	iconBraces,
 	iconEye,
 	iconFile,
+	iconFolderPlus,
 	iconImage,
 	iconSearch,
 	iconText,
 	iconTrash,
 	iconUpload,
+	iconWarning,
 	pictoDocumentGradient,
 } from "@surrealdb/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Fragment, useRef, useState } from "react";
+import { Fragment, useMemo, useRef, useState } from "react";
 import { useConfirmation } from "~/providers/Confirmation";
 import type { SpectronScopeSets } from "~/types";
 import { formatFileSize, showErrorNotification, showInfo } from "~/util/helpers";
 import { ContextHero } from "../../components/ContextHero";
 import { EmptyState, PageError, SpectronGate } from "../../components/feedback";
 import type { ContextViewProps } from "../../types";
+import { normalizeScopePath, validateScopePath } from "../../utils/scope-validation";
 import classes from "./style.module.scss";
 
 // The SDK doesn't export the per-document JSON shape as a public alias, so we
@@ -953,22 +958,68 @@ interface UploadItem {
  * `"org/apple" OR ("team/x" AND "clearance/secret")`. Empty inherits the
  * uploader's full write region.
  */
+/** Splits the free-text scope draft into a deduped set of AND-ed paths. */
+function parseScopeDraft(draft: string): string[] {
+	return Array.from(new Set(draft.trim().split(/\s+/).filter(Boolean)));
+}
+
 function ScopeSetsField({
 	value,
 	onChange,
+	draft,
+	onDraftChange,
+	availableScopes,
+	onRegister,
+	registering,
+	error,
+	onError,
 	disabled,
 }: {
 	value: SpectronScopeSets;
 	onChange: (value: SpectronScopeSets) => void;
+	draft: string;
+	onDraftChange: (value: string) => void;
+	availableScopes: string[];
+	onRegister: (paths: string[]) => void;
+	registering: boolean;
+	error: string | null;
+	onError: (message: string | null) => void;
 	disabled?: boolean;
 }) {
-	const [draft, setDraft] = useState("");
+	const known = useMemo(() => new Set(availableScopes), [availableScopes]);
+
+	// Well-formed paths typed in the field that aren't registered yet — these are
+	// the ones the inline "Register" affordance offers to create. (#745)
+	const unknownPaths =
+		availableScopes.length > 0
+			? parseScopeDraft(draft).filter((p) => validateScopePath(p) === null && !known.has(p))
+			: [];
 
 	const addSet = () => {
-		const paths = Array.from(new Set(draft.trim().split(/\s+/).filter(Boolean)));
+		const paths = parseScopeDraft(draft);
 		if (paths.length === 0) return;
+
+		const formatError = paths.map(validateScopePath).find((e): e is string => e !== null);
+		if (formatError) {
+			onError(formatError);
+			return;
+		}
+
+		// Reject scopes that aren't registered so a document isn't pinned to a
+		// scope that doesn't exist. (#736)
+		if (availableScopes.length > 0) {
+			const missing = paths.filter((p) => !known.has(p));
+			if (missing.length > 0) {
+				onError(
+					`Unknown scope${missing.length > 1 ? "s" : ""}: ${missing.join(", ")}. Register ${missing.length > 1 ? "them" : "it"} or pick a suggestion.`,
+				);
+				return;
+			}
+		}
+
 		onChange([...value, paths]);
-		setDraft("");
+		onDraftChange("");
+		onError(null);
 	};
 
 	const removeSet = (index: number) => {
@@ -1012,13 +1063,19 @@ function ScopeSetsField({
 				wrap="nowrap"
 				align="flex-end"
 			>
-				<TextInput
+				<Autocomplete
 					flex={1}
 					label="Scope set"
 					placeholder="e.g. team/x clearance/secret"
 					value={draft}
+					data={availableScopes}
 					disabled={disabled}
-					onChange={(event) => setDraft(event.currentTarget.value)}
+					onChange={(val) => {
+						onDraftChange(val);
+						if (error) {
+							onError(null);
+						}
+					}}
 					onKeyDown={(event) => {
 						if (event.key === "Enter") {
 							event.preventDefault();
@@ -1034,6 +1091,36 @@ function ScopeSetsField({
 					Add set
 				</Button>
 			</Group>
+
+			{error && (
+				<Group
+					gap="xs"
+					wrap="nowrap"
+					align="center"
+				>
+					<Text
+						fz="xs"
+						c="red"
+						flex={1}
+					>
+						{error}
+					</Text>
+					{unknownPaths.length > 0 && (
+						<Button
+							size="compact-xs"
+							variant="subtle"
+							leftSection={<Icon path={iconFolderPlus} />}
+							loading={registering}
+							disabled={disabled}
+							onClick={() => onRegister(unknownPaths)}
+						>
+							{unknownPaths.length > 1
+								? `Register ${unknownPaths.length} scopes`
+								: `Register "${unknownPaths[0]}"`}
+						</Button>
+					)}
+				</Group>
+			)}
 
 			{value.length > 0 && (
 				<Stack gap={4}>
@@ -1128,17 +1215,70 @@ function UploadModal({
 	onClose: () => void;
 	onUploaded: () => void;
 }) {
+	const queryClient = useQueryClient();
 	const inputRef = useRef<HTMLInputElement>(null);
 	const [items, setItems] = useState<UploadItem[]>([]);
 	const [busy, setBusy] = useState(false);
 	const [dragging, setDragging] = useState(false);
 	const [scopes, setScopes] = useState<SpectronScopeSets>([]);
+	const [scopeDraft, setScopeDraft] = useState("");
+	const [scopeError, setScopeError] = useState<string | null>(null);
+
+	const scopesQueryKey = ["spectron", client.contextId, "scopes", "list"];
+
+	// Registered scopes power autocomplete + validation in the scope field. (#736, #745)
+	const scopesQuery = useQuery({
+		queryKey: scopesQueryKey,
+		queryFn: () => client.scopes.list(),
+		retry: false,
+		enabled: opened,
+	});
+
+	const availableScopes = useMemo(
+		() =>
+			(scopesQuery.data ?? [])
+				.map((scope) => normalizeScopePath(scope.path))
+				.filter((path) => path.length > 0),
+		[scopesQuery.data],
+	);
+
+	const registerScopes = useMutation({
+		mutationFn: async (paths: string[]) => {
+			for (const path of paths) {
+				await client.scopes.register({ path });
+			}
+		},
+		onSuccess: (_data, paths) => {
+			queryClient.invalidateQueries({ queryKey: scopesQueryKey });
+			showInfo({
+				title: paths.length > 1 ? "Scopes registered" : "Scope registered",
+				subtitle: paths.join(", "),
+			});
+		},
+		onError: (err) => {
+			showErrorNotification({ title: "Couldn't register scope", content: err });
+		},
+	});
+
+	// Register the unknown paths, then commit the whole draft as a set. (#745)
+	const handleRegisterScopes = async (paths: string[]) => {
+		try {
+			await registerScopes.mutateAsync(paths);
+			setScopes((prev) => [...prev, parseScopeDraft(scopeDraft)]);
+			setScopeDraft("");
+			setScopeError(null);
+		} catch {
+			// The mutation already surfaced the error via a notification.
+		}
+	};
 
 	const reset = () => {
 		setItems([]);
 		setBusy(false);
 		setDragging(false);
 		setScopes([]);
+		setScopeDraft("");
+		setScopeError(null);
 	};
 
 	const handleClose = () => {
@@ -1169,6 +1309,30 @@ function UploadModal({
 			.filter(({ item }) => item.state === "pending" || item.state === "failed");
 		if (queue.length === 0) return;
 
+		// Auto-commit any text still in the scope field so the user doesn't have to
+		// click "Add set" before uploading. (#745)
+		const scopeSets = scopeDraft.trim() ? [...scopes, parseScopeDraft(scopeDraft)] : scopes;
+
+		// Reject unknown scopes up front so the failure is loud and explained here
+		// rather than a silent per-file server rejection. (#736)
+		if (availableScopes.length > 0) {
+			const known = new Set(availableScopes);
+			const unknown = Array.from(new Set(scopeSets.flat())).filter((p) => !known.has(p));
+			if (unknown.length > 0) {
+				setScopeError(
+					`Unknown scope${unknown.length > 1 ? "s" : ""}: ${unknown.join(", ")}. Register ${unknown.length > 1 ? "them" : "it"}, or pick from the suggestions, before uploading.`,
+				);
+				return;
+			}
+		}
+		setScopeError(null);
+
+		// Reflect the committed draft in the visible chips.
+		if (scopeDraft.trim()) {
+			setScopes(scopeSets);
+			setScopeDraft("");
+		}
+
 		setBusy(true);
 
 		const update = (index: number, patch: Partial<UploadItem>) => {
@@ -1176,6 +1340,7 @@ function UploadModal({
 		};
 
 		let anySucceeded = false;
+		let anyFailed = false;
 
 		for (const { item, index } of queue) {
 			update(index, { state: "uploading", error: undefined });
@@ -1185,7 +1350,7 @@ function UploadModal({
 					filename: item.file.name,
 					title: item.file.name,
 					contentType: item.file.type || undefined,
-					scopes: scopes.length > 0 ? scopes : undefined,
+					scopes: scopeSets.length > 0 ? scopeSets : undefined,
 				});
 				update(index, { state: "done", deduplicated: result.deduplicated });
 				anySucceeded = true;
@@ -1194,10 +1359,18 @@ function UploadModal({
 					state: "failed",
 					error: err instanceof Error ? err.message : String(err),
 				});
+				anyFailed = true;
 			}
 		}
 
 		setBusy(false);
+
+		if (anyFailed) {
+			showErrorNotification({
+				title: "Some uploads failed",
+				content: new Error("See the highlighted files below for details."),
+			});
+		}
 
 		if (anySucceeded) {
 			onUploaded();
@@ -1205,6 +1378,10 @@ function UploadModal({
 				title: "Upload complete",
 				subtitle: "Spectron is processing your documents.",
 			});
+			// Auto-close once everything uploaded cleanly. (#735)
+			if (!anyFailed) {
+				handleClose();
+			}
 		}
 	};
 
@@ -1302,9 +1479,39 @@ function UploadModal({
 					</Stack>
 				)}
 
+				{items.some((item) => item.state === "failed") && (
+					<Alert
+						color="red"
+						variant="light"
+						icon={<Icon path={iconWarning} />}
+						title="Some uploads failed"
+					>
+						<Stack gap={4}>
+							{items
+								.filter((item) => item.state === "failed")
+								.map((item, idx) => (
+									<Text
+										key={`${item.file.name}-${idx}`}
+										fz="sm"
+										className="selectable"
+									>
+										<b>{item.file.name}</b>: {item.error ?? "Upload failed"}
+									</Text>
+								))}
+						</Stack>
+					</Alert>
+				)}
+
 				<ScopeSetsField
 					value={scopes}
 					onChange={setScopes}
+					draft={scopeDraft}
+					onDraftChange={setScopeDraft}
+					availableScopes={availableScopes}
+					onRegister={handleRegisterScopes}
+					registering={registerScopes.isPending}
+					error={scopeError}
+					onError={setScopeError}
 					disabled={busy}
 				/>
 

--- a/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
@@ -1525,7 +1525,6 @@ function UploadModal({
 						{items.some((item) => item.state === "done") ? "Done" : "Cancel"}
 					</Button>
 					<Button
-						variant="default"
 						leftSection={<Icon path={iconUpload} />}
 						onClick={() => inputRef.current?.click()}
 						disabled={busy}

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/index.tsx
@@ -32,7 +32,9 @@ import type { CloudContext, ContextViewPage } from "~/types";
 import { ContextHero } from "../../components/ContextHero";
 import type { ContextViewProps } from "../../types";
 import { buildClaudeCodeSteps } from "./integrations/claude-code";
+import { buildCursorSteps } from "./integrations/cursor";
 import { buildLangChainSteps } from "./integrations/langchain";
+import { buildMcpSteps } from "./integrations/mcp";
 import { buildN8nSteps } from "./integrations/n8n";
 import { buildOpenAiAgentsSteps } from "./integrations/openai-agents";
 import { getSpectronUrls } from "./integrations/spectron-urls";
@@ -45,6 +47,8 @@ type IntegrationTab =
 	| "javascript"
 	| "api"
 	| "claude-code"
+	| "cursor"
+	| "mcp"
 	| "n8n"
 	| "langchain"
 	| "openai-agents"
@@ -55,6 +59,8 @@ const INTEGRATION_TABS: IntegrationTab[] = [
 	"javascript",
 	"api",
 	"claude-code",
+	"cursor",
+	"mcp",
 	"n8n",
 	"langchain",
 	"openai-agents",
@@ -66,6 +72,8 @@ const TAB_META: Record<IntegrationTab, { label: string; img?: string; icon?: str
 	javascript: { label: "JavaScript", img: brandJavaScript },
 	api: { label: "REST API", icon: iconAPI },
 	"claude-code": { label: "Claude Code", icon: iconMCP },
+	cursor: { label: "Cursor", icon: iconMCP },
+	mcp: { label: "MCP", icon: iconMCP },
 	n8n: { label: "n8n", img: brandN8N },
 	langchain: { label: "LangChain", img: brandLangchain },
 	"openai-agents": { label: "OpenAI Agents", img: brandOpenAi },
@@ -221,6 +229,8 @@ await session.turn({ role: TurnRole.assistant, content: "Got it, Alex — noted.
 			},
 		],
 		"claude-code": buildClaudeCodeSteps(context),
+		cursor: buildCursorSteps(context),
+		mcp: buildMcpSteps(context),
 		n8n: buildN8nSteps(context),
 		langchain: buildLangChainSteps(context),
 		"openai-agents": buildOpenAiAgentsSteps(context),
@@ -234,6 +244,8 @@ function isIntegrationTab(v: string | undefined): v is IntegrationTab {
 		v === "javascript" ||
 		v === "api" ||
 		v === "claude-code" ||
+		v === "cursor" ||
+		v === "mcp" ||
 		v === "n8n" ||
 		v === "langchain" ||
 		v === "openai-agents" ||

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/cursor.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/cursor.tsx
@@ -1,0 +1,55 @@
+import type { CloudContext } from "~/types";
+import { getSpectronUrls } from "./spectron-urls";
+import type { IntegrationStep } from "./types";
+
+export function buildCursorSteps(context: CloudContext): IntegrationStep[] {
+	const { mcpUrl } = getSpectronUrls(context);
+
+	return [
+		{
+			title: "Install the MCP server",
+			description:
+				"Run the installer once. It prompts for your API key and adds Spectron to Cursor's MCP configuration for this context.",
+			code: `npx install-mcp spectron --client cursor --context ${context.id}`,
+			lang: "bash",
+			action: "api_keys",
+		},
+		{
+			title: "Config location",
+			description:
+				"Cursor reads MCP servers from ~/.cursor/mcp.json (global) or .cursor/mcp.json (per project). The installer creates or updates this file.",
+			code: "~/.cursor/mcp.json",
+			lang: "bash",
+		},
+		{
+			title: "Configuration reference",
+			description:
+				"The block uses your context host for the MCP endpoint, your agent API key as a Bearer token, and the X-Spectron-Context header.",
+			code: `{
+  "mcpServers": {
+    "spectron": {
+      "url": "${mcpUrl}",
+      "headers": {
+        "Authorization": "Bearer your-api-key",
+        "X-Spectron-Context": "${context.id}"
+      }
+    }
+  }
+}`,
+			lang: "json",
+		},
+		{
+			title: "Verify",
+			description:
+				"Open Cursor → Settings → MCP and confirm the Spectron server is connected and its memory and knowledge tools are listed.",
+		},
+		{
+			title: "Explore Spectron",
+			description:
+				"See the full Cursor setup guide, scope headers, and usage patterns in the documentation.",
+			action: "documentation",
+			documentationUrl:
+				"https://surrealdb.com/docs/spectron/integrations/mcp-server/coding-assistants/cursor",
+		},
+	];
+}

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/mcp.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/mcp.tsx
@@ -1,0 +1,47 @@
+import type { CloudContext } from "~/types";
+import { getSpectronUrls } from "./spectron-urls";
+import type { IntegrationStep } from "./types";
+
+export function buildMcpSteps(context: CloudContext): IntegrationStep[] {
+	const { mcpUrl } = getSpectronUrls(context);
+
+	return [
+		{
+			title: "Create an API key",
+			description:
+				"The MCP server authenticates with a scoped API key bound to your principal. Create one for this context.",
+			action: "api_keys",
+		},
+		{
+			title: "MCP endpoint",
+			description:
+				"Spectron exposes a streamable HTTP MCP server. Point any MCP-compatible client at this URL.",
+			code: mcpUrl,
+			lang: "bash",
+		},
+		{
+			title: "Configuration reference",
+			description:
+				"Most MCP clients accept a server entry like this. Send your API key as a Bearer token and select this context with the X-Spectron-Context header.",
+			code: `{
+  "mcpServers": {
+    "spectron": {
+      "url": "${mcpUrl}",
+      "headers": {
+        "Authorization": "Bearer your-api-key",
+        "X-Spectron-Context": "${context.id}"
+      }
+    }
+  }
+}`,
+			lang: "json",
+		},
+		{
+			title: "Explore Spectron",
+			description:
+				"Read the MCP server reference for the available memory and knowledge tools, scope headers, and authentication.",
+			action: "documentation",
+			documentationUrl: "https://surrealdb.com/docs/spectron/integrations/mcp-server",
+		},
+	];
+}

--- a/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
@@ -28,6 +28,8 @@ import {
 	iconRefresh,
 	iconRelation,
 	iconTag,
+	iconText,
+	iconUpload,
 	iconWarning,
 	pictoSpectronGradient,
 	SectionTitle,
@@ -35,37 +37,17 @@ import {
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import { ContentPane } from "~/components/Pane";
 import { useIsLight } from "~/hooks/theme";
-import { showErrorNotification } from "~/util/helpers";
+import { useConfirmation } from "~/providers/Confirmation";
+import {
+	type ChatMessage,
+	type ExtractionResult,
+	type MemoryHit,
+	usePlaygroundStore,
+} from "~/stores/playground";
+import { showErrorNotification, showInfo } from "~/util/helpers";
 import { SpectronGate } from "../../components/feedback";
 import type { ContextViewProps } from "../../types";
 import classes from "./style.module.scss";
-
-// ─── SDK-derived types (inferred from method returns) ───
-
-// `chat` is overloaded (non-streaming vs `{ stream: true }`). A plain
-// `ReturnType` collapses to the last (streaming) overload, so this matches the
-// FIRST call signature to recover the non-streaming `ChatResponseJson` shape —
-// the one that carries `memoryUpdates`.
-type FirstChatReturn<T> = T extends {
-	(message: string, options?: infer _O): infer R;
-	(message: string, options: infer _O2): infer _R2;
-}
-	? R
-	: never;
-
-type ChatResponse = Awaited<FirstChatReturn<Spectron["chat"]>>;
-type RecallResult = Awaited<ReturnType<Spectron["recall"]>>;
-type MemoryHit = RecallResult["hits"][number];
-type ExtractionResult = ChatResponse["memoryUpdates"];
-type SessionHandle = Awaited<ReturnType<Spectron["sessions"]["create"]>>;
-
-interface ChatMessage {
-	id: string;
-	role: "user" | "assistant";
-	content: string;
-	traceId?: string;
-	fresh?: boolean;
-}
 
 const EXAMPLE_PROMPTS = [
 	"My name is Alex and I prefer dark mode.",
@@ -73,6 +55,11 @@ const EXAMPLE_PROMPTS = [
 	"What do you know about me?",
 	"Remind me to review the Q3 roadmap on Friday.",
 ];
+
+// Stable empty fallbacks so selecting a not-yet-seeded conversation doesn't
+// return a fresh array on every render (which would thrash memoised children).
+const EMPTY_MESSAGES: ChatMessage[] = [];
+const EMPTY_HITS: MemoryHit[] = [];
 
 // ─── Page shell ───
 
@@ -96,15 +83,23 @@ export default function PlaygroundView({ context }: ContextViewProps) {
 function Playground({ client }: { client: Spectron; context: ContextViewProps["context"] }) {
 	const isLight = useIsLight();
 	const glassColor = isLight ? "rgba(0, 0, 0, 0.05)" : "rgba(255, 255, 255, 0.05)";
+	const contextId = client.contextId;
 
-	const [messages, setMessages] = useState<ChatMessage[]>([]);
-	const [input, setInput] = useState("");
-	const [recalled, setRecalled] = useState<MemoryHit[]>([]);
-	const [learned, setLearned] = useState<ExtractionResult | null>(null);
-	const [busy, setBusy] = useState(false);
-	const [recalling, setRecalling] = useState(false);
+	// Conversation state lives in a store keyed by context id, so leaving the
+	// Playground and returning restores the thread — and a reply that is still
+	// processing lands in the store instead of being discarded. (#734)
+	const conversation = usePlaygroundStore((s) => s.conversations[contextId]);
+	const setInputStore = usePlaygroundStore((s) => s.setInput);
+	const sendMessage = usePlaygroundStore((s) => s.send);
+	const resetConversation = usePlaygroundStore((s) => s.reset);
 
-	const sessionRef = useRef<SessionHandle | null>(null);
+	const messages = conversation?.messages ?? EMPTY_MESSAGES;
+	const input = conversation?.input ?? "";
+	const recalled = conversation?.recalled ?? EMPTY_HITS;
+	const learned = conversation?.learned ?? null;
+	const busy = conversation?.busy ?? false;
+	const recalling = conversation?.recalling ?? false;
+
 	const viewportRef = useRef<HTMLDivElement>(null);
 
 	const scrollToBottom = useCallback(() => {
@@ -124,85 +119,114 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 		}
 	}, [scrollToBottom, threadLength, busy]);
 
-	const resetSession = useCallback(() => {
-		const previous = sessionRef.current;
-		sessionRef.current = null;
-		setMessages([]);
-		setRecalled([]);
-		setLearned(null);
-		setInput("");
-		// Best-effort server-side cleanup; ignore failures.
-		previous?.close().catch(() => {});
-	}, []);
+	// When the user switches to a different context while the Playground stays
+	// mounted, close the previous context's session so handles don't accumulate.
+	// Navigating to another view in the SAME context unmounts this component
+	// without changing contextId, so the conversation still survives. (#734)
+	const previousContextId = useRef(contextId);
+	useEffect(() => {
+		if (previousContextId.current !== contextId) {
+			resetConversation(previousContextId.current);
+			previousContextId.current = contextId;
+		}
+	}, [contextId, resetConversation]);
+
+	const setInput = useCallback(
+		(value: string) => setInputStore(contextId, value),
+		[setInputStore, contextId],
+	);
+
+	const resetSession = useCallback(
+		() => resetConversation(contextId),
+		[resetConversation, contextId],
+	);
 
 	const send = useCallback(
-		async (raw: string) => {
-			const text = raw.trim();
-			if (!text || busy) return;
-
-			setInput("");
-			setMessages((prev) => [
-				...prev,
-				{ id: crypto.randomUUID(), role: "user", content: text },
-			]);
-			setLearned(null);
-			setBusy(true);
-			setRecalling(true);
-
-			try {
-				// Lazily open a session on first send.
-				if (!sessionRef.current) {
-					sessionRef.current = await client.sessions.create({});
-				}
-				const sessionId = sessionRef.current.id;
-
-				// Recall (what the agent retrieves) + chat (the reply + what it
-				// learns) run concurrently. Non-streaming chat is used so the
-				// `memoryUpdates` payload — the whole point of the Learned panel —
-				// is always populated.
-				const recallPromise = client
-					.recall(text, { k: 6, sessionId })
-					.then((res) => {
-						setRecalled(res.hits);
-					})
-					.finally(() => setRecalling(false));
-
-				const chatPromise = client.chat(text, { sessionId });
-
-				// `res.sessionId` echoes the id we attached the turn to; the
-				// session handle already carries it, so no reassignment needed.
-				const [, res] = await Promise.all([recallPromise, chatPromise]);
-
-				setMessages((prev) => [
-					...prev,
-					{
-						id: crypto.randomUUID(),
-						role: "assistant",
-						content: res.reply,
-						traceId: res.traceId,
-						fresh: true,
-					},
-				]);
-				setLearned(res.memoryUpdates);
-			} catch (err) {
-				showErrorNotification({ title: "Chat failed", content: err });
-			} finally {
-				setBusy(false);
-				setRecalling(false);
-			}
+		(raw: string) => {
+			void sendMessage(contextId, client, raw);
 		},
-		[busy, client],
+		[sendMessage, contextId, client],
 	);
 
 	const handleKeyDown = useCallback(
 		(e: React.KeyboardEvent) => {
 			if (e.key === "Enter" && !e.shiftKey) {
 				e.preventDefault();
-				void send(input);
+				send(input);
 			}
 		},
 		[input, send],
 	);
+
+	// ── Add documents straight from the chat: drag-and-drop a file (#751) or
+	// save a message as an authoritative document (#753). Both go to the
+	// context's document store via the same upload path the Documents view uses.
+	const [dragging, setDragging] = useState(false);
+
+	const uploadFiles = useCallback(
+		async (files: File[]) => {
+			if (files.length === 0) return;
+			let uploaded = 0;
+			for (const file of files) {
+				try {
+					await client.documents.upload({
+						file,
+						filename: file.name,
+						title: file.name,
+						contentType: file.type || undefined,
+					});
+					uploaded++;
+				} catch (err) {
+					showErrorNotification({
+						title: `Couldn't upload ${file.name}`,
+						content: err,
+					});
+				}
+			}
+			if (uploaded > 0) {
+				showInfo({
+					title: uploaded === 1 ? "Document uploaded" : `${uploaded} documents uploaded`,
+					subtitle: "Spectron is processing it and will ground future answers in it.",
+				});
+			}
+		},
+		[client],
+	);
+
+	const confirmSaveAsDocument = useConfirmation<string>({
+		title: "Save as document",
+		message:
+			"Add this message to the context as an authoritative document? Spectron will parse, embed, and use it to ground future answers.",
+		confirmText: "Save",
+		confirmProps: { variant: "gradient" },
+		skippable: true,
+		onConfirm: async (content) => {
+			const file = new File([content], `chat-message-${Date.now()}.md`, {
+				type: "text/markdown",
+			});
+			await uploadFiles([file]);
+		},
+	});
+
+	const handleDragOver = (event: React.DragEvent) => {
+		if (!event.dataTransfer.types.includes("Files")) return;
+		event.preventDefault();
+		setDragging(true);
+	};
+
+	const handleDragLeave = (event: React.DragEvent) => {
+		// Ignore moves between children; only clear when the cursor truly leaves.
+		if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+			setDragging(false);
+		}
+	};
+
+	const handleDrop = (event: React.DragEvent) => {
+		if (!event.dataTransfer.types.includes("Files")) return;
+		event.preventDefault();
+		setDragging(false);
+		void uploadFiles(Array.from(event.dataTransfer.files));
+	};
 
 	const hasConversation = messages.length > 0 || recalled.length > 0 || learned !== null;
 	const showWelcome = messages.length === 0 && !busy;
@@ -231,7 +255,33 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 					</Tooltip>
 				}
 			>
-				<Box className={classes.chatBody}>
+				<Box
+					className={classes.chatBody}
+					pos="relative"
+					onDragOver={handleDragOver}
+					onDragLeave={handleDragLeave}
+					onDrop={handleDrop}
+				>
+					{dragging && (
+						<Center className={classes.dropOverlay}>
+							<Stack
+								align="center"
+								gap="xs"
+							>
+								<Icon
+									path={iconUpload}
+									size="xl"
+									c="violet"
+								/>
+								<Text
+									fw={600}
+									c="bright"
+								>
+									Drop files to add them to this context
+								</Text>
+							</Stack>
+						</Center>
+					)}
 					<Box
 						flex={1}
 						pos="relative"
@@ -322,6 +372,9 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 											key={msg.id}
 											message={msg}
 											isLight={isLight}
+											onSaveAsDocument={() =>
+												confirmSaveAsDocument(msg.content)
+											}
 										/>
 									))}
 									{busy && <PendingBubble />}
@@ -429,15 +482,46 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 
 // ─── Chat bubbles ───
 
-function ChatBubble({ message, isLight }: { message: ChatMessage; isLight: boolean }) {
+function ChatBubble({
+	message,
+	isLight,
+	onSaveAsDocument,
+}: {
+	message: ChatMessage;
+	isLight: boolean;
+	onSaveAsDocument: () => void;
+}) {
+	const saveAction = (
+		<Tooltip label="Save as document">
+			<ActionIcon
+				variant="subtle"
+				color="slate"
+				size="sm"
+				className={classes.messageAction}
+				aria-label="Save this message as a document"
+				onClick={onSaveAsDocument}
+			>
+				<Icon path={iconText} />
+			</ActionIcon>
+		</Tooltip>
+	);
+
 	if (message.role === "user") {
 		return (
 			<Paper
 				p="md"
 				bg={isLight ? "obsidian.1" : "obsidian.6"}
-				className="selectable"
+				className={`${classes.message} selectable`}
 			>
-				<Text style={{ whiteSpace: "pre-wrap" }}>{message.content}</Text>
+				<Group
+					justify="space-between"
+					align="flex-start"
+					gap="xs"
+					wrap="nowrap"
+				>
+					<Text style={{ whiteSpace: "pre-wrap" }}>{message.content}</Text>
+					{saveAction}
+				</Group>
 			</Paper>
 		);
 	}
@@ -445,14 +529,22 @@ function ChatBubble({ message, isLight }: { message: ChatMessage; isLight: boole
 	return (
 		<Box
 			mb="md"
-			className={message.fresh ? classes.fadeIn : undefined}
+			className={`${classes.message} ${message.fresh ? classes.fadeIn : ""}`}
 		>
-			<Text
-				className="selectable"
-				style={{ whiteSpace: "pre-wrap" }}
+			<Group
+				justify="space-between"
+				align="flex-start"
+				gap="xs"
+				wrap="nowrap"
 			>
-				{message.content}
-			</Text>
+				<Text
+					className="selectable"
+					style={{ whiteSpace: "pre-wrap" }}
+				>
+					{message.content}
+				</Text>
+				{saveAction}
+			</Group>
 			{message.traceId && (
 				<Text
 					mt={4}

--- a/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
@@ -31,6 +31,7 @@ import {
 	iconText,
 	iconUpload,
 	iconWarning,
+	MarkdownViewer,
 	pictoSpectronGradient,
 	SectionTitle,
 } from "@surrealdb/ui";
@@ -519,7 +520,9 @@ function ChatBubble({
 					gap="xs"
 					wrap="nowrap"
 				>
-					<Text style={{ whiteSpace: "pre-wrap" }}>{message.content}</Text>
+					<Box flex={1}>
+						<MarkdownViewer content={message.content} />
+					</Box>
 					{saveAction}
 				</Group>
 			</Paper>
@@ -537,12 +540,12 @@ function ChatBubble({
 				gap="xs"
 				wrap="nowrap"
 			>
-				<Text
+				<Box
+					flex={1}
 					className="selectable"
-					style={{ whiteSpace: "pre-wrap" }}
 				>
-					{message.content}
-				</Text>
+					<MarkdownViewer content={message.content} />
+				</Box>
 				{saveAction}
 			</Group>
 			{message.traceId && (

--- a/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
@@ -391,13 +391,10 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 					>
 						<Group
 							gap="sm"
-							align="end"
+							align="center"
 							wrap="nowrap"
 						>
 							<Textarea
-								mt="lg"
-								bg={glassColor}
-								bdrs="xl"
 								flex={1}
 								placeholder="Message your agent…"
 								value={input}
@@ -408,16 +405,6 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 								maxRows={5}
 								disabled={busy}
 								aria-label="Message"
-								variant="unstyled"
-								styles={{
-									input: {
-										color: "var(--mantine-color-bright)",
-										padding: "0.5rem 1rem",
-									},
-								}}
-								style={{
-									border: "1px solid rgba(255, 255, 255, 0.25)",
-								}}
 							/>
 							<ActionIcon
 								size="xl"

--- a/src/screens/surrealist/pages/Context/views/PlaygroundView/style.module.scss
+++ b/src/screens/surrealist/pages/Context/views/PlaygroundView/style.module.scss
@@ -69,6 +69,39 @@
 	}
 }
 
+.message {
+	position: relative;
+}
+
+.message-action {
+	opacity: 0;
+	transition: opacity 120ms ease;
+
+	.message:hover &,
+	.message:focus-within & {
+		opacity: 1;
+	}
+}
+
+// Pointer-less devices can't hover, so keep the action reachable there.
+@media (hover: none) {
+	.message-action {
+		opacity: 1;
+	}
+}
+
+.drop-overlay {
+	position: absolute;
+	inset: var(--mantine-spacing-sm);
+	z-index: 5;
+	border-radius: var(--mantine-radius-lg);
+	border: 2px dashed var(--mantine-color-violet-5);
+	background: color-mix(in srgb, var(--mantine-color-violet-5) 12%, transparent);
+	backdrop-filter: blur(2px);
+	// Let drag/drop events fall through to the chat-body handler underneath.
+	pointer-events: none;
+}
+
 .clamp {
 	display: -webkit-box;
 	-webkit-line-clamp: 3;

--- a/src/screens/surrealist/pages/Context/views/ScopesView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/ScopesView/index.tsx
@@ -37,6 +37,7 @@ import { showErrorNotification, showInfo } from "~/util/helpers";
 import { ContextHero } from "../../components/ContextHero";
 import { EmptyState, PageError, SpectronGate } from "../../components/feedback";
 import type { ContextViewProps } from "../../types";
+import { validateScopePath } from "../../utils/scope-validation";
 import classes from "./style.module.scss";
 
 // The SDK declares `ScopeNodeJson` as a non-exported local alias, so we recover
@@ -74,6 +75,26 @@ function buildTree(nodes: ScopeNodeJson[]): ScopeTreeNode[] {
 		// Drop the trailing empty segment from the canonical trailing slash.
 		const segments = node.path.split("/").filter((s) => s.length > 0);
 		if (segments.length === 0) {
+			// The root scope (path "/" or empty) folds to no segments. Surface it
+			// as a top-level node instead of dropping it, so a registered root
+			// scope still appears in the tree and the tab's count matches the
+			// Overview scope count. (#738)
+			const existing = byPath.get("/");
+			if (existing) {
+				existing.registered = true;
+				existing.tombstonedAt = node.tombstonedAt;
+			} else {
+				const root: ScopeTreeNode = {
+					segment: "/",
+					path: "/",
+					registered: true,
+					tombstonedAt: node.tombstonedAt,
+					depth: 0,
+					children: [],
+				};
+				byPath.set("/", root);
+				roots.push(root);
+			}
 			continue;
 		}
 
@@ -124,37 +145,6 @@ function defaultExpanded(roots: ScopeTreeNode[]): Set<string> {
 	};
 	roots.forEach(walk);
 	return open;
-}
-
-// ─── Path validation ───
-
-const SEGMENT = /^[a-z0-9][a-z0-9._-]*$/;
-
-/**
- * Validates a slash-separated scope path: lowercase segments, no spaces, no
- * `=` or `*`, and no empty segments. Returns an error string, or `null` when
- * the path is acceptable.
- */
-function validatePath(raw: string): string | null {
-	const value = raw.trim();
-	if (!value) {
-		return "Enter a scope path";
-	}
-	if (/\s/.test(value)) {
-		return "Paths cannot contain spaces";
-	}
-	if (value.includes("=") || value.includes("*")) {
-		return "Paths cannot contain '=' or '*'";
-	}
-
-	const segments = value.replace(/\/+$/, "").split("/");
-	if (segments.some((s) => s.length === 0)) {
-		return "Paths cannot contain empty segments";
-	}
-	if (!segments.every((s) => SEGMENT.test(s))) {
-		return "Use lowercase segments like org/apple/product";
-	}
-	return null;
 }
 
 // ─── Page ───
@@ -553,7 +543,7 @@ function RegisterModal({
 		}
 	}
 
-	const validationError = validatePath(path);
+	const validationError = validateScopePath(path);
 	const canonical = path.trim().replace(/\/+$/, "");
 	const duplicate =
 		!validationError &&

--- a/src/screens/surrealist/pages/Context/views/SettingsView/tabs/Principals.tsx
+++ b/src/screens/surrealist/pages/Context/views/SettingsView/tabs/Principals.tsx
@@ -1323,12 +1323,7 @@ function MintedKeyModal({
 							fresh key from the API Keys view to get a value you can copy.
 						</Alert>
 						<Group justify="flex-end">
-							<Button
-								variant="default"
-								onClick={onClose}
-							>
-								Close
-							</Button>
+							<Button onClick={onClose}>Close</Button>
 						</Group>
 					</Stack>
 				))}

--- a/src/screens/surrealist/pages/Context/views/SettingsView/tabs/Principals.tsx
+++ b/src/screens/surrealist/pages/Context/views/SettingsView/tabs/Principals.tsx
@@ -145,10 +145,11 @@ export function PrincipalsTab({ context, kind }: ContextViewProps & { kind: Owne
 
 	const isHuman = kind === "human";
 
+	// Always reveal after minting — a guard here previously swallowed the secret
+	// silently, and the reveal is shown in a modal so it can't be missed
+	// regardless of how far down the principal list the action was triggered.
 	const onKeyMinted = (key: ContextApiKey) => {
-		if (key.key) {
-			setMintedKey(key);
-		}
+		setMintedKey(key);
 	};
 
 	return (
@@ -170,12 +171,10 @@ export function PrincipalsTab({ context, kind }: ContextViewProps & { kind: Owne
 				/>
 			</ContextHero>
 
-			{mintedKey?.key && (
-				<MintedKeyAlert
-					apiKey={mintedKey}
-					onDismiss={() => setMintedKey(null)}
-				/>
-			)}
+			<MintedKeyModal
+				apiKey={mintedKey}
+				onClose={() => setMintedKey(null)}
+			/>
 
 			<Box>
 				<SectionTitle
@@ -1252,40 +1251,87 @@ function ContextKeysSection({
 
 // ─── One-time secret reveal ───
 
-function MintedKeyAlert({ apiKey, onDismiss }: { apiKey: ContextApiKey; onDismiss: () => void }) {
+/**
+ * Reveals a freshly minted key's secret in a modal so it is impossible to miss,
+ * even when the "Mint key" action was triggered far down the principal list. If
+ * the server didn't return a secret, it explains where to get a usable key
+ * rather than failing silently.
+ */
+function MintedKeyModal({
+	apiKey,
+	onClose,
+}: {
+	apiKey: ContextApiKey | null;
+	onClose: () => void;
+}) {
 	return (
-		<Alert
-			color="blue"
-			variant="light"
-			title={`Key "${apiKey.name}" is ready`}
-			withCloseButton
-			onClose={onDismiss}
-			icon={<Icon path={iconKey} />}
+		<Modal
+			opened={apiKey !== null}
+			onClose={onClose}
+			title={<Text fw={600}>{apiKey ? `Key "${apiKey.name}" is ready` : "Key ready"}</Text>}
 		>
-			<Text
-				mb="xs"
-				className="selectable"
-			>
-				Copy this secret now — it will not be shown again.
-			</Text>
-			<CopyButton value={apiKey.key ?? ""}>
-				{({ copied, copy }) => (
-					<TextInput
-						value={apiKey.key ?? ""}
-						variant="unstyled"
-						readOnly
-						onFocus={ON_FOCUS_SELECT}
-						onClick={copy}
-						styles={{ input: { fontFamily: "var(--mantine-font-family-monospace)" } }}
-						leftSection={
-							<Icon
-								path={copied ? iconCheck : iconCopy}
-								c="bright"
-							/>
-						}
-					/>
-				)}
-			</CopyButton>
-		</Alert>
+			{apiKey &&
+				(apiKey.key ? (
+					<Stack gap="md">
+						<Alert
+							color="orange"
+							variant="light"
+							icon={<Icon path={iconKey} />}
+						>
+							Copy this secret now — it will not be shown again.
+						</Alert>
+						<CopyButton value={apiKey.key}>
+							{({ copied, copy }) => (
+								<TextInput
+									label="Secret"
+									value={apiKey.key ?? ""}
+									readOnly
+									onFocus={ON_FOCUS_SELECT}
+									onClick={copy}
+									styles={{
+										input: {
+											fontFamily: "var(--mantine-font-family-monospace)",
+										},
+									}}
+									leftSection={
+										<Icon
+											path={copied ? iconCheck : iconCopy}
+											c="bright"
+										/>
+									}
+								/>
+							)}
+						</CopyButton>
+						<Group justify="flex-end">
+							<Button
+								variant="gradient"
+								onClick={onClose}
+							>
+								Done
+							</Button>
+						</Group>
+					</Stack>
+				) : (
+					<Stack gap="md">
+						<Alert
+							color="orange"
+							variant="light"
+							title="Secret not returned"
+							icon={<Icon path={iconKey} />}
+						>
+							The key was created, but the server didn't return its secret. Issue a
+							fresh key from the API Keys view to get a value you can copy.
+						</Alert>
+						<Group justify="flex-end">
+							<Button
+								variant="default"
+								onClick={onClose}
+							>
+								Close
+							</Button>
+						</Group>
+					</Stack>
+				))}
+		</Modal>
 	);
 }

--- a/src/screens/surrealist/pages/Organization/sidebar.tsx
+++ b/src/screens/surrealist/pages/Organization/sidebar.tsx
@@ -134,7 +134,7 @@ export function OrganisationSidebar({ organizationId }: OrganisationSidebarProps
 			<SidebarNavigation
 				items={navigation}
 				backButton={{
-					name: "Overview",
+					name: "Back",
 					onClick: () => setLocation("/"),
 				}}
 			/>

--- a/src/screens/surrealist/pages/OrganizationContextCheckout/index.tsx
+++ b/src/screens/surrealist/pages/OrganizationContextCheckout/index.tsx
@@ -109,7 +109,7 @@ function PageContent({ organisation }: PageContentProps) {
 			if (redirect) {
 				navigate(redirect);
 			} else {
-				navigate(`/o/${organisation.id}/billing`);
+				navigate(`/o/${organisation.id}/contexts`);
 			}
 		} catch (err: unknown) {
 			const message = err instanceof Error ? err.message : String(err);

--- a/src/screens/surrealist/pages/OrganizationContextDeploy/index.tsx
+++ b/src/screens/surrealist/pages/OrganizationContextDeploy/index.tsx
@@ -48,26 +48,30 @@ import { ON_FOCUS_SELECT, showErrorNotification } from "~/util/helpers";
 import { PageContainer } from "../../components/PageContainer";
 import classes from "./style.module.scss";
 
+// Business-outcome framing (draft for PM review, #748): each card speaks to a
+// user benefit rather than the underlying engine mechanic.
 const SPECTRON_HIGHLIGHTS: { label: string; description: string; icon: string }[] = [
 	{
-		label: "ACID memory",
-		description: "Atomic writes across entities, facts, and embeddings.",
-		icon: iconServerSecure,
-	},
-	{
-		label: "Temporal facts",
-		description: "Bi-temporal history - know what was true and when.",
-		icon: iconCloudClock,
-	},
-	{
-		label: "Hybrid retrieval",
-		description: "Graph, vectors, and filters in a single query.",
+		label: "Answers you can trust",
+		description: "Every answer is grounded in stored facts you can trace back to their source.",
 		icon: iconRelation,
 	},
 	{
-		label: "Multi-agent",
-		description: "Shared memory for coordinated agent swarms.",
+		label: "Always up to date",
+		description:
+			"Knows what's true now versus what was true before, so stale facts don't resurface.",
+		icon: iconCloudClock,
+	},
+	{
+		label: "Access on your terms",
+		description: "Decide exactly which memories each user and agent is allowed to see.",
 		icon: iconAuth,
+	},
+	{
+		label: "Your data stays yours",
+		description:
+			"Memory lives in an isolated context you control — never shared, never trained on.",
+		icon: iconServerSecure,
 	},
 ];
 
@@ -196,10 +200,10 @@ function PageContent({ organisation }: PageContentProps) {
 								lh={1.55}
 								className="selectable"
 							>
-								A context is a dedicated Spectron environment: ingest conversations
-								and documents, extract structure, and retrieve with hybrid search.
-								Choose a suitable name and the region where memory will reside to
-								get started.
+								A context is your agent's private memory layer — it remembers what
+								matters from every conversation and document, keeps it current, and
+								serves it back with sources you can trust. Name it and choose a
+								region to get started.
 							</Text>
 						</Box>
 						<Group
@@ -230,170 +234,150 @@ function PageContent({ organisation }: PageContentProps) {
 						</Group>
 					</Paper>
 
-					<SimpleGrid
+					<Paper
 						mt="xl"
-						spacing={48}
-						cols={{ base: 1, md: 2 }}
+						p="xl"
+						radius="md"
 					>
-						<Paper
-							p="xl"
-							radius="md"
-						>
-							<Stack gap="xl">
-								<SectionTitle
-									kicker="Configuration"
-									order={2}
-								>
-									Build your context
-								</SectionTitle>
-
-								{blockedWithoutPlan && (
-									<Alert
-										color="orange"
-										title="Spectron plan required"
-									>
-										<Text className="selectable">
-											This organisation does not have an active Spectron plan.
-											Only the organisation owner can subscribe to a plan.
-											Contact your organisation owner to continue.
-										</Text>
-									</Alert>
-								)}
-
-								<TextInput
-									label="Name"
-									placeholder="e.g. Production context"
-									value={name}
-									onChange={(e) => setName(e.currentTarget.value)}
-									onFocus={ON_FOCUS_SELECT}
-									autoFocus
-									disabled={blockedWithoutPlan}
-									error={
-										name.length > 30
-											? "Context name cannot exceed 30 characters"
-											: null
-									}
-								/>
-
-								<Box>
-									<Label id={regionGroupLabelId}>Region</Label>
-									<Box
-										role="radiogroup"
-										aria-labelledby={regionGroupLabelId}
-									>
-										<SimpleGrid
-											cols={{ base: 1, xs: 2, md: 1, lg: 2 }}
-											spacing="md"
-										>
-											{supportedRegions.map((r) => {
-												const selected = region === r.slug;
-
-												return (
-													<Option
-														key={r.slug}
-														label={r.description}
-														checked={selected}
-														disabled={blockedWithoutPlan}
-														onChange={() => setRegion(r.slug)}
-														withBorder
-														py="md"
-														icon={
-															<Image
-																src={REGION_FLAGS[r.slug]}
-																w={18}
-															/>
-														}
-													/>
-												);
-											})}
-										</SimpleGrid>
-									</Box>
-								</Box>
-
-								<Group>
-									<Button
-										onClick={() => navigate(`/o/${organisation.id}/contexts`)}
-									>
-										Back
-									</Button>
-									<Spacer />
-									<Button
-										variant="gradient"
-										disabled={!canDeploy || blockedWithoutPlan}
-										loading={isDeploying}
-										onClick={handleDeploy}
-									>
-										Create context
-									</Button>
-								</Group>
-							</Stack>
-						</Paper>
-						<Stack
-							gap="lg"
-							visibleFrom="md"
-						>
-							<Box>
-								<SectionTitle
-									kicker="What you get"
-									order={2}
-								>
-									Agent memory that actually works
-								</SectionTitle>
-								<Text
-									mt="sm"
-									fz="sm"
-									lh={1.6}
-									className="selectable"
-								>
-									Each context is provisioned with SurrealDB&apos;s Spectron
-									pipeline - the same model described in your context dashboard
-									after deployment.
-								</Text>
-							</Box>
-							<SimpleGrid
-								cols={{ base: 1, sm: 2 }}
-								spacing="sm"
+						<Stack gap="xl">
+							<SectionTitle
+								kicker="Configuration"
+								order={2}
 							>
-								{SPECTRON_HIGHLIGHTS.map((item) => (
-									<Paper
-										key={item.label}
-										p="md"
+								Build your context
+							</SectionTitle>
+
+							{blockedWithoutPlan && (
+								<Alert
+									color="orange"
+									title="Spectron plan required"
+								>
+									<Text className="selectable">
+										This organisation does not have an active Spectron plan.
+										Only the organisation owner can subscribe to a plan. Contact
+										your organisation owner to continue.
+									</Text>
+								</Alert>
+							)}
+
+							<TextInput
+								label="Name"
+								placeholder="e.g. Production context"
+								value={name}
+								onChange={(e) => setName(e.currentTarget.value)}
+								onFocus={ON_FOCUS_SELECT}
+								autoFocus
+								disabled={blockedWithoutPlan}
+								error={
+									name.length > 30
+										? "Context name cannot exceed 30 characters"
+										: null
+								}
+							/>
+
+							<Box>
+								<Label id={regionGroupLabelId}>Region</Label>
+								<Box
+									role="radiogroup"
+									aria-labelledby={regionGroupLabelId}
+								>
+									<SimpleGrid
+										cols={{ base: 1, xs: 2, md: 1, lg: 2 }}
+										spacing="md"
 									>
-										<Group
-											gap="sm"
-											wrap="nowrap"
-											align="flex-start"
-										>
-											<ThemeIcon
-												size={34}
-												radius="md"
-												variant="light"
-												color="violet"
-											>
-												<Icon path={item.icon} />
-											</ThemeIcon>
-											<Box miw={0}>
-												<Text
-													fw={600}
-													c="bright"
-												>
-													{item.label}
-												</Text>
-												<Text
-													fz="sm"
-													lh={1.45}
-													mt={2}
-													className="selectable"
-												>
-													{item.description}
-												</Text>
-											</Box>
-										</Group>
-									</Paper>
-								))}
-							</SimpleGrid>
+										{supportedRegions.map((r) => {
+											const selected = region === r.slug;
+
+											return (
+												<Option
+													key={r.slug}
+													label={r.description}
+													checked={selected}
+													disabled={blockedWithoutPlan}
+													onChange={() => setRegion(r.slug)}
+													withBorder
+													py="md"
+													icon={
+														<Image
+															src={REGION_FLAGS[r.slug]}
+															w={18}
+														/>
+													}
+												/>
+											);
+										})}
+									</SimpleGrid>
+								</Box>
+							</Box>
+
+							<Group>
+								<Button onClick={() => navigate(`/o/${organisation.id}/contexts`)}>
+									Back
+								</Button>
+								<Spacer />
+								<Button
+									variant="gradient"
+									disabled={!canDeploy || blockedWithoutPlan}
+									loading={isDeploying}
+									onClick={handleDeploy}
+								>
+									Create context
+								</Button>
+							</Group>
 						</Stack>
-					</SimpleGrid>
+					</Paper>
+
+					<Box mt="xl">
+						<SectionTitle
+							kicker="What you get"
+							order={2}
+						>
+							Why teams build on Spectron
+						</SectionTitle>
+						<SimpleGrid
+							mt="lg"
+							cols={{ base: 1, sm: 2, lg: 4 }}
+							spacing="md"
+						>
+							{SPECTRON_HIGHLIGHTS.map((item) => (
+								<Paper
+									key={item.label}
+									p="md"
+								>
+									<Group
+										gap="sm"
+										wrap="nowrap"
+										align="flex-start"
+									>
+										<ThemeIcon
+											size={34}
+											radius="md"
+											variant="light"
+											color="violet"
+										>
+											<Icon path={item.icon} />
+										</ThemeIcon>
+										<Box miw={0}>
+											<Text
+												fw={600}
+												c="bright"
+											>
+												{item.label}
+											</Text>
+											<Text
+												fz="sm"
+												lh={1.45}
+												mt={2}
+												className="selectable"
+											>
+												{item.description}
+											</Text>
+										</Box>
+									</Group>
+								</Paper>
+							))}
+						</SimpleGrid>
+					</Box>
 				</PageContainer>
 			</CloudAdminGuard>
 		</>

--- a/src/stores/playground.tsx
+++ b/src/stores/playground.tsx
@@ -1,0 +1,184 @@
+import type { Spectron } from "@surrealdb/spectron";
+import { create } from "zustand";
+import { immer } from "zustand/middleware/immer";
+import { showErrorNotification } from "~/util/helpers";
+
+// ─── SDK-derived types (inferred from method returns) ───
+
+// `chat` is overloaded (non-streaming vs `{ stream: true }`). A plain
+// `ReturnType` collapses to the last (streaming) overload, so this matches the
+// FIRST call signature to recover the non-streaming `ChatResponseJson` shape —
+// the one that carries `memoryUpdates`.
+type FirstChatReturn<T> = T extends {
+	(message: string, options?: infer _O): infer R;
+	(message: string, options: infer _O2): infer _R2;
+}
+	? R
+	: never;
+
+type ChatResponse = Awaited<FirstChatReturn<Spectron["chat"]>>;
+type RecallResult = Awaited<ReturnType<Spectron["recall"]>>;
+export type MemoryHit = RecallResult["hits"][number];
+export type ExtractionResult = ChatResponse["memoryUpdates"];
+type SessionHandle = Awaited<ReturnType<Spectron["sessions"]["create"]>>;
+
+export interface ChatMessage {
+	id: string;
+	role: "user" | "assistant";
+	content: string;
+	traceId?: string;
+	fresh?: boolean;
+}
+
+interface PlaygroundConversation {
+	messages: ChatMessage[];
+	input: string;
+	recalled: MemoryHit[];
+	learned: ExtractionResult | null;
+	busy: boolean;
+	recalling: boolean;
+}
+
+/**
+ * Live session handles are kept outside the immer store: they are class
+ * instances with methods, which immer would freeze (breaking them), and they
+ * never need to drive React renders. The store only holds serialisable
+ * conversation state.
+ */
+const sessionHandles = new Map<string, SessionHandle>();
+
+function emptyConversation(): PlaygroundConversation {
+	return {
+		messages: [],
+		input: "",
+		recalled: [],
+		learned: null,
+		busy: false,
+		recalling: false,
+	};
+}
+
+export interface PlaygroundStore {
+	/** Conversation state keyed by Spectron context id. */
+	conversations: Record<string, PlaygroundConversation>;
+
+	setInput: (contextId: string, value: string) => void;
+	/**
+	 * Sends a message in the given context. Writes results straight to the store
+	 * so an in-flight reply still lands (and stays visible on return) even if the
+	 * user navigates away from the Playground while it is processing.
+	 */
+	send: (contextId: string, client: Spectron, raw: string) => Promise<void>;
+	/** Clears the conversation and closes the server-side session. */
+	reset: (contextId: string) => void;
+}
+
+export const usePlaygroundStore = create<PlaygroundStore>()(
+	immer((set, get) => ({
+		conversations: {},
+
+		setInput: (contextId, value) =>
+			set((draft) => {
+				if (!draft.conversations[contextId]) {
+					draft.conversations[contextId] = emptyConversation();
+				}
+				draft.conversations[contextId].input = value;
+			}),
+
+		send: async (contextId, client, raw) => {
+			const text = raw.trim();
+			if (!text || get().conversations[contextId]?.busy) {
+				return;
+			}
+
+			set((draft) => {
+				if (!draft.conversations[contextId]) {
+					draft.conversations[contextId] = emptyConversation();
+				}
+				const conv = draft.conversations[contextId];
+				conv.input = "";
+				// Only the newest message should fade in on render.
+				for (const msg of conv.messages) {
+					msg.fresh = false;
+				}
+				conv.messages.push({ id: crypto.randomUUID(), role: "user", content: text });
+				conv.learned = null;
+				conv.busy = true;
+				conv.recalling = true;
+			});
+
+			try {
+				// Lazily open a session on first send.
+				let session = sessionHandles.get(contextId);
+				if (!session) {
+					session = await client.sessions.create({});
+					sessionHandles.set(contextId, session);
+				}
+				const sessionId = session.id;
+
+				// Recall (what the agent retrieves) + chat (the reply + what it
+				// learns) run concurrently. Non-streaming chat is used so the
+				// `memoryUpdates` payload — the whole point of the Learned panel —
+				// is always populated.
+				const recallPromise = client
+					.recall(text, { k: 6, sessionId })
+					.then((res) => {
+						set((draft) => {
+							const conv = draft.conversations[contextId];
+							if (conv) {
+								conv.recalled = res.hits;
+							}
+						});
+					})
+					.finally(() => {
+						set((draft) => {
+							const conv = draft.conversations[contextId];
+							if (conv) {
+								conv.recalling = false;
+							}
+						});
+					});
+
+				const chatPromise = client.chat(text, { sessionId });
+
+				const [, res] = await Promise.all([recallPromise, chatPromise]);
+
+				set((draft) => {
+					const conv = draft.conversations[contextId];
+					if (!conv) return;
+					for (const msg of conv.messages) {
+						msg.fresh = false;
+					}
+					conv.messages.push({
+						id: crypto.randomUUID(),
+						role: "assistant",
+						content: res.reply,
+						traceId: res.traceId,
+						fresh: true,
+					});
+					conv.learned = res.memoryUpdates;
+				});
+			} catch (err) {
+				showErrorNotification({ title: "Chat failed", content: err });
+			} finally {
+				set((draft) => {
+					const conv = draft.conversations[contextId];
+					if (conv) {
+						conv.busy = false;
+						conv.recalling = false;
+					}
+				});
+			}
+		},
+
+		reset: (contextId) => {
+			const previous = sessionHandles.get(contextId);
+			sessionHandles.delete(contextId);
+			// Best-effort server-side cleanup; ignore failures.
+			previous?.close().catch(() => {});
+			set((draft) => {
+				draft.conversations[contextId] = emptyConversation();
+			});
+		},
+	})),
+);


### PR DESCRIPTION
Implements the Surrealist frontend items raised in the June 2026 Spectron pre-release testing round.

## What changed

**Playground**
- Conversation is no longer wiped when you leave the Playground and return. Chat state now lives in a Zustand store (`src/stores/playground.tsx`) keyed by context id, and an in-flight reply lands in the store instead of being discarded. Switching contexts closes the previous context's session so handles don't accumulate.
- Drag-and-drop files onto the chat to add them to the context's document store.
- Per-message **Save as document** action (with a confirmation) that ingests the message via the existing upload path.

**Documents**
- The upload drawer auto-closes once everything has uploaded cleanly (stays open if any file failed).
- Upload failures are surfaced loudly (inline alert + toast), and unknown scopes are rejected up front instead of failing silently.
- The scope field autocompletes against registered scopes, auto-commits the typed draft on upload (no more mandatory "Add set"), and can register a new scope inline. Scope-path validation is extracted into a shared util reused by the Scopes view.

**Scopes / Overview**
- `buildTree` now surfaces a root/empty-path scope instead of dropping it, so the Scopes tab count matches the Overview tile.
- Overview stat tiles (Documents / Entities / Scopes / Queries) are now clickable links to their views.

**Settings / Billing / Navigation**
- A freshly minted key is revealed in a modal (with a clear fallback when the server doesn't return a secret) so it can't be missed.
- The "Create API key" modal's grant-pattern fields autocomplete against the context's registered scopes.
- Post-subscription redirect now lands on **Contexts** instead of Billing.
- The org sidebar back button is renamed **Back** (it previously read "Overview", duplicating the resource link).

**Create-a-Context (deploy) page**
- Streamlined the redundant side-by-side boxes into a single-column form with the benefit cards below.
- Reworded the benefit cards to business outcomes.
- Replaced inaccurate "bi-temporal" wording with "tri-temporal" / plain-language framing.

**Integrations**
- Added **Cursor** and generic **MCP** integration guides.

## Not included
A few items from the testing round are out of scope for this frontend PR: several are blocked on backend/SDK work (a trace status field for filtering failed chat turns, a document-rename endpoint, an entity scope-filter parameter), the "long answers get cut off" report is a backend response cap rather than a frontend limit, the Playground how-to docs belong in the docs site, the `->` rendering nit appears to be upstream in `@surrealdb/ui`'s Shiki `CodeBlock`, and the knowledge-graph node styling was deferred as a larger feature.

## Testing
- `tsc --noEmit`: 0 errors
- `biome check`: clean
- Dev server boots with no build or console errors
- Adversarial code-review pass over the diff; one real finding (session-handle accumulation on context switch) was addressed. The Spectron context views are Cloud-auth-gated, so deeper interactive verification wasn't possible in this environment.
