### PR TITLE
Fix "Selection points outside of document" crash when creating a record

### DIFF
--- a/src/providers/Inspector/tabs/create.tsx
+++ b/src/providers/Inspector/tabs/create.tsx
@@ -99,13 +99,13 @@ export function CreateTab({ table, content, onCreated }: CreateTabProps) {
 	});
 
 	const setCursor = useStable((view: EditorView) => {
-		if (content) {
-			const length = view.state.doc.length;
+		// Clamp the cursor to the document length. When creating a fresh record the
+		// editor content may not be populated yet by the time this fires, so an
+		// unclamped position would throw "Selection points outside of document".
+		const length = view.state.doc.length;
+		const position = content ? length : Math.min(6, length);
 
-			view.dispatch({ selection: { anchor: length, head: length } });
-		} else {
-			view.dispatch({ selection: { anchor: 6, head: 6 } });
-		}
+		view.dispatch({ selection: { anchor: position, head: position } });
 	});
 
 	useLayoutEffect(() => {


### PR DESCRIPTION
## Summary

Fixes #1276.
Fixes #1270 (same root cause — the differing stack traces are just the web vs. Tauri builds; both bottom out at CodeMirror's selection bounds check during "Create record").

Creating a new record in the Explorer view could crash with a CodeMirror error:

> `Selection points outside of document`

The stack trace originates from a CodeMirror transaction `dispatch`. The reporter confirmed it's a regression — present in 3.9.2/3.9.4, not in 3.8.6.

## Root cause

The Create tab (`src/providers/Inspector/tabs/create.tsx`, introduced in the 3.9.0 inspector refactor) positions the editor cursor on mount:

```ts
const setCursor = useStable((view: EditorView) => {
	if (content) {
		const length = view.state.doc.length;
		view.dispatch({ selection: { anchor: length, head: length } });
	} else {
		view.dispatch({ selection: { anchor: 6, head: 6 } }); // hardcoded offset
	}
});
```

For a fresh record it dispatches a selection at a hardcoded offset of `6` (meant to land inside the default `{\n    \n}` body). However, the editor's content comes from the `value` prop, which is populated asynchronously (`recordBody` starts as `""` and is set in a `useLayoutEffect`). When `onMount` fires before the value has been applied, the document is still empty (length `0`), so a selection at offset `6` is out of bounds and CodeMirror throws.

This is timing-sensitive, which is why it surfaces reliably under the software renderer / windowed mode described in the issue. The `content` branch already reads `doc.length`, so it was unaffected.

## Fix

Clamp the cursor position to the current document length so the dispatched selection is always in bounds. Normal behavior is unchanged (offset `6` when the default body is present); in the race where the document is still empty, the cursor simply lands at the start instead of crashing.

```ts
const setCursor = useStable((view: EditorView) => {
	const length = view.state.doc.length;
	const position = content ? length : Math.min(6, length);
	view.dispatch({ selection: { anchor: position, head: position } });
});
```

## Testing

- `biome check` passes on the changed file.
- `tsc --noEmit` reports only pre-existing, unrelated errors (in the `Context`/Spectron module); nothing from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
