### PR TITLE
Spectron testing-round fixes: Playground, Memory graph & Documents (#741, #746, #737, #755, #750)

### DIFF
--- a/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/DocumentsView/index.tsx
@@ -26,6 +26,9 @@ import type { Spectron } from "@surrealdb/spectron";
 import {
 	Icon,
 	iconBraces,
+	iconCheck,
+	iconClose,
+	iconEdit,
 	iconEye,
 	iconFile,
 	iconFolderPlus,
@@ -38,7 +41,7 @@ import {
 	pictoDocumentGradient,
 } from "@surrealdb/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Fragment, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { useConfirmation } from "~/providers/Confirmation";
 import type { SpectronScopeSets } from "~/types";
 import { formatFileSize, showErrorNotification, showInfo } from "~/util/helpers";
@@ -289,6 +292,10 @@ function DocumentExplorer({ client }: { client: Spectron }) {
 				client={client}
 				document={inspecting}
 				onClose={() => setInspecting(null)}
+				onRenamed={(updated) => {
+					setInspecting(updated);
+					invalidateList();
+				}}
 			/>
 		</Stack>
 	);
@@ -676,10 +683,12 @@ function InspectorDrawer({
 	client,
 	document: doc,
 	onClose,
+	onRenamed,
 }: {
 	client: Spectron;
 	document: DocumentEntry | null;
 	onClose: () => void;
+	onRenamed: (document: DocumentEntry) => void;
 }) {
 	const [chunkPage, setChunkPage] = useState(1);
 
@@ -720,9 +729,155 @@ function InspectorDrawer({
 					document={doc}
 					chunkPage={chunkPage}
 					onChunkPageChange={setChunkPage}
+					onRenamed={onRenamed}
 				/>
 			)}
 		</Drawer>
+	);
+}
+
+// Editable document name. There is no dedicated rename endpoint, so the only
+// way to change the stored title is to reprocess the document — we round-trip
+// its existing bytes with the new title. That re-runs the ingestion pipeline,
+// so we tell the user the document will be re-processed. (#750)
+function DocumentNameField({
+	client,
+	document: doc,
+	onRenamed,
+}: {
+	client: Spectron;
+	document: DocumentEntry;
+	onRenamed: (document: DocumentEntry) => void;
+}) {
+	const [editing, setEditing] = useState(false);
+	const [title, setTitle] = useState(doc.title ?? "");
+
+	// Re-sync the field whenever the inspected document's title changes.
+	useEffect(() => {
+		setTitle(doc.title ?? "");
+		setEditing(false);
+	}, [doc.title]);
+
+	const rename = useMutation({
+		mutationFn: async (nextTitle: string) => {
+			const bytes = await client.documents.raw(doc.id);
+			await client.documents.reprocess(doc.id, {
+				file: new Blob([bytes], {
+					type: doc.mimeType || "application/octet-stream",
+				}),
+				filename: doc.source || doc.title || doc.id,
+				title: nextTitle,
+				contentType: doc.mimeType || undefined,
+			});
+			return client.documents.get(doc.id);
+		},
+		onSuccess: (updated) => {
+			onRenamed(updated);
+			setEditing(false);
+			showInfo({
+				title: "Document renamed",
+				subtitle: "Spectron is re-processing it under the new name.",
+			});
+		},
+		onError: (err) => {
+			showErrorNotification({ title: "Couldn't rename document", content: err });
+		},
+	});
+
+	const trimmed = title.trim();
+	const canSave = trimmed.length > 0 && trimmed !== (doc.title ?? "") && !rename.isPending;
+
+	const cancel = () => {
+		setTitle(doc.title ?? "");
+		setEditing(false);
+	};
+
+	if (!editing) {
+		return (
+			<Group
+				gap="xs"
+				wrap="nowrap"
+				align="center"
+			>
+				<Text
+					fw={600}
+					c="bright"
+					flex={1}
+					truncate
+					className="selectable"
+				>
+					{doc.title || doc.source || "Untitled document"}
+				</Text>
+				<Tooltip label="Rename">
+					<ActionIcon
+						variant="subtle"
+						color="slate"
+						size="sm"
+						aria-label="Rename document"
+						onClick={() => setEditing(true)}
+					>
+						<Icon path={iconEdit} />
+					</ActionIcon>
+				</Tooltip>
+			</Group>
+		);
+	}
+
+	return (
+		<Stack gap={4}>
+			<Group
+				gap="xs"
+				wrap="nowrap"
+				align="center"
+			>
+				<TextInput
+					flex={1}
+					value={title}
+					autoFocus
+					disabled={rename.isPending}
+					aria-label="Document name"
+					onChange={(event) => setTitle(event.currentTarget.value)}
+					onKeyDown={(event) => {
+						if (event.key === "Enter" && canSave) {
+							event.preventDefault();
+							rename.mutate(trimmed);
+						} else if (event.key === "Escape") {
+							event.preventDefault();
+							cancel();
+						}
+					}}
+				/>
+				<Tooltip label="Save">
+					<ActionIcon
+						variant="light"
+						color="green"
+						aria-label="Save name"
+						disabled={!canSave}
+						loading={rename.isPending}
+						onClick={() => rename.mutate(trimmed)}
+					>
+						<Icon path={iconCheck} />
+					</ActionIcon>
+				</Tooltip>
+				<Tooltip label="Cancel">
+					<ActionIcon
+						variant="subtle"
+						color="slate"
+						aria-label="Cancel rename"
+						disabled={rename.isPending}
+						onClick={cancel}
+					>
+						<Icon path={iconClose} />
+					</ActionIcon>
+				</Tooltip>
+			</Group>
+			<Text
+				fz="xs"
+				c="slate"
+			>
+				Renaming re-processes the document so retrieval stays in sync.
+			</Text>
+		</Stack>
 	);
 }
 
@@ -731,11 +886,13 @@ function InspectorBody({
 	document: doc,
 	chunkPage,
 	onChunkPageChange,
+	onRenamed,
 }: {
 	client: Spectron;
 	document: DocumentEntry;
 	chunkPage: number;
 	onChunkPageChange: (page: number) => void;
+	onRenamed: (document: DocumentEntry) => void;
 }) {
 	const chunksQuery = useQuery({
 		queryKey: ["spectron", client.contextId, "documents", "chunks", doc.id, chunkPage],
@@ -753,6 +910,12 @@ function InspectorBody({
 
 	return (
 		<Stack gap="lg">
+			<DocumentNameField
+				client={client}
+				document={doc}
+				onRenamed={onRenamed}
+			/>
+
 			<Stack gap={6}>
 				<MetaRow label="Status">
 					<StatusBadge

--- a/src/screens/surrealist/pages/Context/views/MemoryView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/MemoryView/index.tsx
@@ -27,12 +27,15 @@ import type { Spectron } from "@surrealdb/spectron";
 import { ScopeError } from "@surrealdb/spectron";
 import {
 	Icon,
+	iconAccount,
+	iconBook,
 	iconChevronRight,
 	iconClock,
 	iconHistory,
 	iconMemory,
 	iconRelation,
 	iconSearch,
+	iconTag,
 	pictoSpectronGradient,
 	SectionTitle,
 } from "@surrealdb/ui";
@@ -58,6 +61,14 @@ const CATEGORY_COLOR: Record<MemoryCategory, string> = {
 	identity: "violet",
 	knowledge: "blue",
 	context: "teal",
+};
+
+// Distinct icon per node type so identity / knowledge / context are eyeballable
+// at a glance in the graph, not just by colour. (#746)
+const CATEGORY_ICON: Record<MemoryCategory, string> = {
+	identity: iconAccount,
+	knowledge: iconBook,
+	context: iconTag,
 };
 
 /** Friendly relative timestamp; falls back to the raw string when unparseable. */
@@ -312,7 +323,7 @@ function CategoryCard({
 					color={color}
 				>
 					<Icon
-						path={iconRelation}
+						path={CATEGORY_ICON[categoryKey]}
 						size="sm"
 					/>
 				</ThemeIcon>
@@ -777,7 +788,7 @@ function EntityCard({ entity, onSelect }: { entity: EntityDetail; onSelect: () =
 						color={color}
 					>
 						<Icon
-							path={iconRelation}
+							path={CATEGORY_ICON[entity.memoryCategory]}
 							size="lg"
 						/>
 					</ThemeIcon>
@@ -895,7 +906,7 @@ function EntityInspectorDrawer({
 								variant="light"
 								color={CATEGORY_COLOR[entity.memoryCategory]}
 							>
-								<Icon path={iconRelation} />
+								<Icon path={CATEGORY_ICON[entity.memoryCategory]} />
 							</ThemeIcon>
 							<Text
 								fw={600}

--- a/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
@@ -796,7 +796,7 @@ function LearnedSection({ learned }: { learned: ExtractionResult | null }) {
 										span
 										c="violet.3"
 									>
-										{" —"}
+										{" →"}
 										{r.label}
 										{"→ "}
 									</Text>

--- a/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
@@ -7,8 +7,10 @@ import {
 	Divider,
 	Group,
 	Image,
+	List,
 	Loader,
 	Paper,
+	Popover,
 	ScrollArea,
 	Skeleton,
 	Stack,
@@ -23,8 +25,10 @@ import {
 	iconBookmark,
 	iconChat,
 	iconCursor,
+	iconHelp,
 	iconHistory,
 	iconMemory,
+	iconOpen,
 	iconRefresh,
 	iconRelation,
 	iconTag,
@@ -36,6 +40,7 @@ import {
 	SectionTitle,
 } from "@surrealdb/ui";
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { adapter } from "~/adapter";
 import { ContentPane } from "~/components/Pane";
 import { useIsLight } from "~/hooks/theme";
 import { useConfirmation } from "~/providers/Confirmation";
@@ -76,6 +81,70 @@ export default function PlaygroundView({ context }: ContextViewProps) {
 				)}
 			</SpectronGate>
 		</Box>
+	);
+}
+
+// ─── Playground help ───
+
+// In-app explainer for the Playground — what it is, how to read the activity
+// panel, and (the most common question) whether you can ask about uploaded
+// documents. The full guide lives in the docs site. (#755)
+function PlaygroundHelp() {
+	return (
+		<Popover
+			width={340}
+			position="bottom-end"
+			withArrow
+			shadow="md"
+		>
+			<Popover.Target>
+				<Button
+					size="xs"
+					variant="subtle"
+					color="slate"
+					leftSection={<Icon path={iconHelp} />}
+				>
+					How it works
+				</Button>
+			</Popover.Target>
+			<Popover.Dropdown>
+				<Stack gap="sm">
+					<Text
+						fw={600}
+						c="bright"
+					>
+						How the Playground works
+					</Text>
+					<List
+						spacing="xs"
+						fz="sm"
+						withPadding
+					>
+						<List.Item>
+							Chat with your agent in real time. Every reply is grounded in what this
+							context remembers.
+						</List.Item>
+						<List.Item>
+							The <b>Memory activity</b> panel shows what was recalled for each
+							message and what the agent just learned.
+						</List.Item>
+						<List.Item>
+							<b>You can ask about your documents.</b> Anything uploaded in the
+							Documents view is retrieved and used to ground answers, with sources it
+							can cite.
+						</List.Item>
+					</List>
+					<Button
+						variant="light"
+						size="xs"
+						rightSection={<Icon path={iconOpen} />}
+						onClick={() => adapter.openUrl("https://surrealdb.com/docs/spectron")}
+					>
+						Read the docs
+					</Button>
+				</Stack>
+			</Popover.Dropdown>
+		</Popover>
 	);
 }
 
@@ -250,18 +319,21 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 				p={0}
 				withTopPadding={false}
 				rightSection={
-					<Tooltip label="Start a fresh session">
-						<Button
-							size="xs"
-							variant="subtle"
-							color="slate"
-							leftSection={<Icon path={iconRefresh} />}
-							onClick={resetSession}
-							disabled={busy || !hasConversation}
-						>
-							New session
-						</Button>
-					</Tooltip>
+					<Group gap="xs">
+						<PlaygroundHelp />
+						<Tooltip label="Start a fresh session">
+							<Button
+								size="xs"
+								variant="subtle"
+								color="slate"
+								leftSection={<Icon path={iconRefresh} />}
+								onClick={resetSession}
+								disabled={busy || !hasConversation}
+							>
+								New session
+							</Button>
+						</Tooltip>
+					</Group>
 				}
 			>
 				<Box
@@ -329,8 +401,8 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 										className="selectable"
 									>
 										Tell it about yourself, then ask what it remembers. Each
-										reply is grounded in recalled memory and may teach it
-										something new.
+										reply is grounded in recalled memory and any documents
+										you've uploaded — and may teach it something new.
 									</Text>
 									<Stack
 										mt={36}

--- a/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/PlaygroundView/index.tsx
@@ -92,6 +92,7 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 	const conversation = usePlaygroundStore((s) => s.conversations[contextId]);
 	const setInputStore = usePlaygroundStore((s) => s.setInput);
 	const sendMessage = usePlaygroundStore((s) => s.send);
+	const retryMessage = usePlaygroundStore((s) => s.retry);
 	const resetConversation = usePlaygroundStore((s) => s.reset);
 
 	const messages = conversation?.messages ?? EMPTY_MESSAGES;
@@ -147,6 +148,13 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 			void sendMessage(contextId, client, raw);
 		},
 		[sendMessage, contextId, client],
+	);
+
+	const retry = useCallback(
+		(messageId: string) => {
+			void retryMessage(contextId, client, messageId);
+		},
+		[retryMessage, contextId, client],
 	);
 
 	const handleKeyDown = useCallback(
@@ -373,6 +381,8 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 											key={msg.id}
 											message={msg}
 											isLight={isLight}
+											busy={busy}
+											onRetry={() => retry(msg.id)}
 											onSaveAsDocument={() =>
 												confirmSaveAsDocument(msg.content)
 											}
@@ -473,10 +483,14 @@ function Playground({ client }: { client: Spectron; context: ContextViewProps["c
 function ChatBubble({
 	message,
 	isLight,
+	busy,
+	onRetry,
 	onSaveAsDocument,
 }: {
 	message: ChatMessage;
 	isLight: boolean;
+	busy: boolean;
+	onRetry: () => void;
 	onSaveAsDocument: () => void;
 }) {
 	const saveAction = (
@@ -500,6 +514,9 @@ function ChatBubble({
 				p="md"
 				bg={isLight ? "obsidian.1" : "obsidian.6"}
 				className={`${classes.message} selectable`}
+				style={
+					message.failed ? { border: "1px solid var(--mantine-color-red-5)" } : undefined
+				}
 			>
 				<Group
 					justify="space-between"
@@ -512,6 +529,41 @@ function ChatBubble({
 					</Box>
 					{saveAction}
 				</Group>
+				{message.failed && (
+					<Group
+						justify="space-between"
+						gap="xs"
+						mt="xs"
+						wrap="nowrap"
+					>
+						<Group
+							gap={6}
+							wrap="nowrap"
+						>
+							<Icon
+								path={iconWarning}
+								size="sm"
+								c="red"
+							/>
+							<Text
+								fz="xs"
+								c="red"
+							>
+								No reply — this turn failed.
+							</Text>
+						</Group>
+						<Button
+							size="compact-xs"
+							variant="light"
+							color="red"
+							leftSection={<Icon path={iconRefresh} />}
+							onClick={onRetry}
+							disabled={busy}
+						>
+							Retry
+						</Button>
+					</Group>
+				)}
 			</Paper>
 		);
 	}

--- a/src/stores/playground.tsx
+++ b/src/stores/playground.tsx
@@ -28,6 +28,8 @@ export interface ChatMessage {
 	content: string;
 	traceId?: string;
 	fresh?: boolean;
+	/** A user turn whose reply never arrived (the request errored or was aborted). */
+	failed?: boolean;
 }
 
 interface PlaygroundConversation {
@@ -69,6 +71,11 @@ export interface PlaygroundStore {
 	 * user navigates away from the Playground while it is processing.
 	 */
 	send: (contextId: string, client: Spectron, raw: string) => Promise<void>;
+	/**
+	 * Re-runs a user turn that previously failed: drops the failed message and
+	 * resends its text, so a 500'd/aborted turn isn't left dangling. (#737)
+	 */
+	retry: (contextId: string, client: Spectron, messageId: string) => Promise<void>;
 	/** Clears the conversation and closes the server-side session. */
 	reset: (contextId: string) => void;
 }
@@ -91,6 +98,9 @@ export const usePlaygroundStore = create<PlaygroundStore>()(
 				return;
 			}
 
+			// Kept so a failed reply can flag exactly this turn (and no other). (#737)
+			const userMessageId = crypto.randomUUID();
+
 			set((draft) => {
 				if (!draft.conversations[contextId]) {
 					draft.conversations[contextId] = emptyConversation();
@@ -101,7 +111,7 @@ export const usePlaygroundStore = create<PlaygroundStore>()(
 				for (const msg of conv.messages) {
 					msg.fresh = false;
 				}
-				conv.messages.push({ id: crypto.randomUUID(), role: "user", content: text });
+				conv.messages.push({ id: userMessageId, role: "user", content: text });
 				conv.learned = null;
 				conv.busy = true;
 				conv.recalling = true;
@@ -159,6 +169,16 @@ export const usePlaygroundStore = create<PlaygroundStore>()(
 					conv.learned = res.memoryUpdates;
 				});
 			} catch (err) {
+				// Flag the turn inline so the failed exchange is clearly marked and
+				// offers a retry, instead of lingering as a silent, reply-less
+				// message. (#737)
+				set((draft) => {
+					const conv = draft.conversations[contextId];
+					const msg = conv?.messages.find((m) => m.id === userMessageId);
+					if (msg) {
+						msg.failed = true;
+					}
+				});
 				showErrorNotification({ title: "Chat failed", content: err });
 			} finally {
 				set((draft) => {
@@ -169,6 +189,25 @@ export const usePlaygroundStore = create<PlaygroundStore>()(
 					}
 				});
 			}
+		},
+
+		retry: async (contextId, client, messageId) => {
+			const conv = get().conversations[contextId];
+			if (!conv || conv.busy) {
+				return;
+			}
+			const target = conv.messages.find((m) => m.id === messageId);
+			if (!target || target.role !== "user") {
+				return;
+			}
+			// Drop the failed turn so resending doesn't duplicate it, then replay.
+			set((draft) => {
+				const draftConv = draft.conversations[contextId];
+				if (draftConv) {
+					draftConv.messages = draftConv.messages.filter((m) => m.id !== messageId);
+				}
+			});
+			await get().send(contextId, client, target.content);
 		},
 
 		reset: (contextId) => {


### PR DESCRIPTION
Revise the Spectron UI and address raised issues.

Fixes surrealdb/spectron#741
Fixes surrealdb/spectron#746
Fixes surrealdb/spectron#737
Fixes surrealdb/spectron#755
Fixes surrealdb/spectron#750

## Implemented

- **spectron#741 — First `->` arrow renders as a plain hyphen.** The Playground "Learned → Relations" panel drew each edge as `subject —label→ object`, using a leading em-dash as the arrow shaft; on its own it reads as a plain hyphen. Now uses a right-arrow glyph on both sides of the label so the edge is unambiguously directional.
- **spectron#746 — Distinct icons/colours per node type.** Identity/knowledge/context nodes in the Memory graph differed only by colour (all used the relation icon). Each category now maps to its own icon (account / book / tag) on the category cards, entity cards, and entity inspector.
- **spectron#737 — Activity shows failed/aborted chat turns.** A chat request that errored left the user's message in the thread with no reply and no indication anything failed. The failed turn is now outlined, labelled "No reply — this turn failed", and offers a **Retry** that replays it without duplicating the message.
- **spectron#755 — Docs: how to use the Playground.** Added an in-app **"How it works"** popover (chat loop, the Memory-activity glass box, and — the most-asked question — that you *can* ask about uploaded documents), plus a note in the welcome copy and a link to the docs site. The full guide still belongs in the docs-site repo.
- **spectron#750 — Rename a document from the Documents view.** Added an inline rename control to the document inspector.

## Testing

No e2e coverage and the Spectron views require auth + a live context, so verification was static: `tsc` (no new type errors — the 4 pre-existing errors are an unrelated installed-SDK version mismatch in `provider.tsx`/upload `scopes`), `biome` clean, and a full `vite build` succeeds. Manual test steps are in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
