### PR TITLE
Fix "Disable animations" setting having no effect

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -36,3 +36,21 @@ a {
 .cm-focused {
 	outline: none !important;
 }
+
+// Disable animations when the "Disable animations" setting is enabled.
+// This drives transition and animation durations to effectively zero so
+// effects such as fading and sliding resolve in a single frame, which also
+// avoids the severe jank they cause on software rendered setups.
+html[data-reduce-motion] {
+	&,
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-delay: 0ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		transition-delay: 0ms !important;
+		scroll-behavior: auto !important;
+	}
+}

--- a/src/components/App/globals.tsx
+++ b/src/components/App/globals.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { adapter } from "~/adapter";
+import { useAppearanceSettings } from "./hooks/appearance";
 import { useConnectionSwitch } from "./hooks/connection";
 import { useEscapeKeyListener, useKeybindListener, useModKeyTracker } from "./hooks/input";
 import { useIntercom } from "./hooks/intercom";
@@ -15,6 +16,7 @@ export function Globals(): ReactNode {
 	useKeybindListener();
 	useEscapeKeyListener();
 	useWindowSettings();
+	useAppearanceSettings();
 	useConnectionSwitch();
 	useTitleSync();
 	useViewSync();

--- a/src/components/App/hooks/appearance.tsx
+++ b/src/components/App/hooks/appearance.tsx
@@ -1,0 +1,14 @@
+import { useLayoutEffect } from "react";
+import { useSetting } from "~/hooks/config";
+
+/**
+ * Synchronize appearance related settings that need to be applied
+ * to the document root element.
+ */
+export function useAppearanceSettings() {
+	const [disableAnimations] = useSetting("appearance", "disableAnimations");
+
+	useLayoutEffect(() => {
+		document.documentElement.toggleAttribute("data-reduce-motion", disableAnimations);
+	}, [disableAnimations]);
+}


### PR DESCRIPTION
## Summary

Fixes #1275.

The **Disable animations** appearance setting (`settings.appearance.disableAnimations`) was defined in the config, had a working toggle in Preferences, and persisted correctly — but it was **never consumed anywhere in the app**. Enabling it did nothing, so fading/sliding effects on modals, dropdowns, the table designer, the hamburger menu, etc. kept playing. On software-rendered Linux setups this causes the multi-second lockups described in the issue.

## Changes

- Add `useAppearanceSettings` hook (wired into `Globals`) that syncs the setting to a `data-reduce-motion` attribute on `<html>`.
- Add a global stylesheet rule that collapses `transition-duration`/`animation-duration` (and delays / iteration count) to effectively zero when that attribute is present. Using `!important` in an unlayered rule means it also overrides Mantine's inline transition styles, so Modal/Menu/Drawer/Popover effects resolve in a single frame.

## Testing

Verified in the dev server:
- Setting defaults off → no `data-reduce-motion` attribute, normal durations.
- Toggling **Disable animations** on in Settings → Preferences adds the attribute; computed `transition-duration`/`animation-duration` drop from their normal values (e.g. `0.5s`/`2s`) to `0.01ms`, and infinite `animation-iteration-count` becomes `1`.
- Toggling it back off removes the attribute and restores normal durations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)