### PR TITLE
Show Spectron contexts as provisioning until ready

### DIFF
--- a/src/cloud/queries/contexts.tsx
+++ b/src/cloud/queries/contexts.tsx
@@ -52,6 +52,9 @@ export function useCloudContextQuery(
 	return useQuery({
 		queryKey: ["cloud", "context", organization, contextId],
 		enabled: !!organization && !!contextId && isAuthenticated && hasCloudSession,
+		// Contexts are provisioned asynchronously; poll while one is still
+		// being created so the page advances to ready on its own.
+		refetchInterval: (query) => (query.state.data?.state === "creating" ? 5_000 : false),
 		queryFn: async () => {
 			const ctx = await fetchAPI<CloudContext>(
 				`/organizations/${organization}/spectron_contexts/${contextId}`,

--- a/src/screens/surrealist/pages/Context/index.tsx
+++ b/src/screens/surrealist/pages/Context/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Center, Loader, Skeleton } from "@mantine/core";
+import { Box, Center, Loader, Skeleton, Stack, Text } from "@mantine/core";
 import { type ComponentType, lazy, memo, Suspense } from "react";
 import { Redirect } from "wouter";
 import { hasOrganizationRoles, ORG_ROLES_ADMIN } from "~/cloud/helpers";
@@ -95,6 +95,12 @@ export function ContextPage({ view }: ContextPageProps) {
 
 	const isFullHeightView = viewPage === "playground";
 
+	// Contexts are provisioned asynchronously: until the state flips to ready
+	// the Spectron endpoint refuses tokens, so gate the whole workspace behind
+	// a waiting view. The context query polls while creating, so this advances
+	// on its own.
+	const isProvisioning = contextQuery.data?.state === "creating";
+
 	const viewContent = (
 		<>
 			{isLoading && (
@@ -104,29 +110,52 @@ export function ContextPage({ view }: ContextPageProps) {
 					mt="sm"
 				/>
 			)}
-			{contextQuery.data && (
-				<SpectronProvider
-					context={contextQuery.data}
-					organizationId={organizationId ?? contextQuery.data.organization_id}
-				>
-					<Suspense
-						fallback={
-							<Center flex={1}>
-								<Loader />
-							</Center>
-						}
+			{contextQuery.data &&
+				(isProvisioning ? (
+					<Center flex={1}>
+						<Stack
+							align="center"
+							gap="lg"
+						>
+							<Loader />
+							<Stack
+								align="center"
+								gap={4}
+							>
+								<Text
+									c="bright"
+									fw={600}
+									fz="xl"
+								>
+									Provisioning your context
+								</Text>
+								<Text>This usually takes a few seconds</Text>
+							</Stack>
+						</Stack>
+					</Center>
+				) : (
+					<SpectronProvider
+						context={contextQuery.data}
+						organizationId={organizationId ?? contextQuery.data.organization_id}
 					>
-						{viewPage === "settings" ? (
-							<SettingsComponent
-								context={contextQuery.data}
-								tab={settingsTab ?? "general"}
-							/>
-						) : Component ? (
-							<Component context={contextQuery.data} />
-						) : null}
-					</Suspense>
-				</SpectronProvider>
-			)}
+						<Suspense
+							fallback={
+								<Center flex={1}>
+									<Loader />
+								</Center>
+							}
+						>
+							{viewPage === "settings" ? (
+								<SettingsComponent
+									context={contextQuery.data}
+									tab={settingsTab ?? "general"}
+								/>
+							) : Component ? (
+								<Component context={contextQuery.data} />
+							) : null}
+						</Suspense>
+					</SpectronProvider>
+				))}
 		</>
 	);
 

--- a/src/screens/surrealist/pages/Organization/tabs/contexts.tsx
+++ b/src/screens/surrealist/pages/Organization/tabs/contexts.tsx
@@ -4,6 +4,7 @@ import {
 	Box,
 	Button,
 	Group,
+	Loader,
 	Paper,
 	Select,
 	SimpleGrid,
@@ -12,6 +13,7 @@ import {
 	Text,
 	TextInput,
 	ThemeIcon,
+	Tooltip,
 } from "@mantine/core";
 import { Icon, iconDotsVertical, iconSearch, iconSpectron, Spacer } from "@surrealdb/ui";
 import { useMemo, useState } from "react";
@@ -85,6 +87,11 @@ function ContextCard({
 								>
 									{context.name}
 								</Text>
+								{context.state === "creating" && (
+									<Tooltip label="Provisioning context...">
+										<Loader size="xs" />
+									</Tooltip>
+								)}
 							</Group>
 							<Text size="sm">
 								{regions.find((r) => r.slug === context.region)?.description ??

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -784,12 +784,20 @@ export interface CloudInstanceCapabilities {
 	denied_arbitrary_query: string[];
 }
 
+export type ContextState = "creating" | "ready";
+
 export interface CloudContext {
 	id: string;
 	organization_id: string;
 	name: string;
 	region: string;
 	host: string;
+	/**
+	 * Provisioning state: contexts are bootstrapped asynchronously and stay
+	 * "creating" until ready. Optional so responses from an older cloud-api
+	 * (predating the field) are treated as ready.
+	 */
+	state?: ContextState;
 }
 
 export interface ContextApiKey {


### PR DESCRIPTION
## Summary

Companion to surrealdb/cloud-api#1044, which makes Spectron Context provisioning **asynchronous** (the instances pattern): create persists the row and returns immediately with a new `state` field (`"creating"` → `"ready"`), a janitor action bootstraps the context in the background, and the access-token broker returns 409 while the context isn't ready.

Without UI awareness, that pending window would surface as a generic "Couldn't connect to this context" token error. This PR mirrors the instance pending pattern for contexts:

- **`CloudContext.state`** (`"creating" | "ready"`, optional): `undefined` from an older cloud-api is treated as ready, so the UI never gates against an API that predates the field.
- **Context cards** show a provisioning spinner (tooltip "Provisioning context...") while creating. The list query already polls every 15s, so cards flip to normal on their own.
- **Context page** gates the workspace behind a "Provisioning your context" waiting view instead of mounting `SpectronProvider` (which would immediately mint a token and hit the 409). `useCloudContextQuery` gains a conditional `refetchInterval` (5s while `creating`, off otherwise), so the page advances to the workspace by itself - including when you navigate straight in from the deploy flow.

## Testing

- `bun run qts` (tsc), `bun run qc` (biome), and a full `bun run build` are clean.
- End-to-end behavior (create → spinner card → provisioning gate → auto-advance to workspace) needs a cloud-api deploy carrying #1044; until then `state` is absent and the UI behaves exactly as before.
