### PR TITLE
Move "From" label above cost on instance plan cards

### DIFF
--- a/src/screens/surrealist/components/PricingCard/index.tsx
+++ b/src/screens/surrealist/components/PricingCard/index.tsx
@@ -87,22 +87,10 @@ export function PricingCard({
 					</Text>
 
 					{isHourly ? (
-						<Group
-							gap={8}
-							align="center"
-							wrap="nowrap"
+						<Stack
+							gap={2}
 							className="selectable"
 						>
-							<Title
-								order={2}
-								c="bright"
-								fz={40}
-								lh={1.1}
-							>
-								{typeof displayPrice === "number"
-									? `$${displayPrice.toFixed(3)}`
-									: displayPrice}
-							</Title>
 							{showFromPerHour && (
 								<Text
 									c="obsidian.4"
@@ -111,11 +99,36 @@ export function PricingCard({
 									lh={1.1}
 								>
 									From
-									<br />
-									{priceSuffix}
 								</Text>
 							)}
-						</Group>
+							<Group
+								gap={8}
+								align="center"
+								wrap="nowrap"
+								className="selectable"
+							>
+								<Title
+									order={2}
+									c="bright"
+									fz={40}
+									lh={1.1}
+								>
+									{typeof displayPrice === "number"
+										? `$${displayPrice.toFixed(3)}`
+										: displayPrice}
+								</Title>
+								{showFromPerHour && (
+									<Text
+										c="obsidian.4"
+										fz="xs"
+										className={clsx(classes.priceSuffix, "selectable")}
+										lh={1.1}
+									>
+										{priceSuffix}
+									</Text>
+								)}
+							</Group>
+						</Stack>
 					) : (
 						<Text
 							fw={600}


### PR DESCRIPTION
## Summary

On the instance plan cards, the "From" label was rendered to the right of the price — stacked on top of the period suffix (e.g. `/hour`) — which read incorrectly. This moves "From" to sit **above** the cost, with the period suffix remaining beside the price.

### Before
```
$0.XXX   From
         /hour
```

### After
```
From
$0.XXX /hour
```

## Changes

- `src/screens/surrealist/components/PricingCard/index.tsx` — wrap the hourly price in a vertical `Stack`, placing the "From" label above the price `Group` and leaving the period suffix beside the cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)