### PR TITLE
Fix migration view redirecting to overview

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -352,8 +352,13 @@ export const VIEW_PAGES: Record<ViewPage, ViewPageInfo> = {
 		id: "migrations",
 		name: "3.0 Migration",
 		icon: iconTransfer,
-		disabled: ({ flags, version }) =>
-			!flags.v3_migration_tooling || !version || !satisfies(version, ">=2.6.1 <3.0.0-0"),
+		disabled: ({ flags, version, instanceVersion }) => {
+			// Prefer the live database version, but fall back to the Cloud instance
+			// version so the view remains reachable before the connection is
+			// established (e.g. when opening the migration flow from the dashboard).
+			const target = version || instanceVersion;
+			return !flags.v3_migration_tooling || !target || !satisfies(target, ">=2.6.1 <3.0.0-0");
+		},
 	},
 	"settings/general": {
 		id: "settings/general",

--- a/src/hooks/connection.ts
+++ b/src/hooks/connection.ts
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { isOrganisationTerminated } from "~/cloud/helpers";
 import { useCloudInstanceList } from "~/cloud/hooks/instances";
+import { useCloudInstanceQuery } from "~/cloud/queries/instances";
 import { GLOBAL_PAGES, SANDBOX, VIEW_PAGES } from "~/constants";
 import { openRequiredDatabaseModal } from "~/modals/require-database";
 import { useConfigStore } from "~/stores/config";
@@ -147,10 +148,13 @@ export function useAvailableViews(): Partial<Record<ViewPage, ViewPageInfo>> {
 	const [flags] = useFeatureFlags();
 	const version = useDatabaseStore((s) => s.version) || null;
 
-	const [connection, isCloud] = useConnection((c) => [
+	const [connection, isCloud, instanceId] = useConnection((c) => [
 		c?.id ?? "",
 		c?.authentication.mode === "cloud",
+		c?.authentication.cloudInstance,
 	]);
+
+	const instanceVersion = useCloudInstanceQuery(instanceId).data?.version || null;
 
 	return useMemo(() => {
 		const draft = { ...VIEW_PAGES } as const;
@@ -159,6 +163,7 @@ export function useAvailableViews(): Partial<Record<ViewPage, ViewPageInfo>> {
 			flags,
 			isCloud,
 			version,
+			instanceVersion,
 		};
 
 		for (const { id, disabled } of Object.values(draft)) {
@@ -168,7 +173,7 @@ export function useAvailableViews(): Partial<Record<ViewPage, ViewPageInfo>> {
 		}
 
 		return draft;
-	}, [flags, connection, isCloud, version]);
+	}, [flags, connection, isCloud, version, instanceVersion]);
 }
 
 /**

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -621,6 +621,7 @@ export interface ViewCondition {
 	flags: FeatureFlagMap;
 	connection: string;
 	version: string | null;
+	instanceVersion: string | null;
 	isCloud: boolean;
 }
 


### PR DESCRIPTION
## Problem

Users on an older 2.6.x Cloud instance who want to upgrade to 3.x are shown a **Start migration** button on the instance dashboard. Clicking it just navigates them back to the overview of all their connections instead of opening the migration flow.

## Cause

The button's visibility (in `MajorUpdateSection`) is gated on the **Cloud instance version** (`instance.version`), which is always available from the Cloud API. The migration view's availability, however, was gated solely on the **live database connection version** (`useDatabaseStore.version`).

When viewing the Cloud dashboard, the database connection is opened asynchronously and may not be established yet (or at all, e.g. for a paused instance). In that window the live version is empty, so `useAvailableViews` filters the `migrations` view out, and `ConnectionPage` falls through to `<Redirect to="/" />` — the connection overview.

## Fix

Thread the Cloud instance version into `ViewCondition` and have the `migrations` view fall back to it when the live database version isn't available yet. The view stays reachable from the dashboard while still being hidden for 3.x databases once connected.

## Testing

- `bun run qts` (typecheck) passes
- `bun run qc` (biome) passes

Reproducing the runtime flow requires a live SurrealDB Cloud account with a 2.6.x instance, so it was verified via type/lint checks and code inspection rather than the browser preview.