### PR TITLE
Fix incorrect Spectron integration card steps

### DIFF
--- a/src/screens/surrealist/pages/Context/views/IntegrationView/index.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/index.tsx
@@ -106,14 +106,14 @@ function buildIntegrationSteps(
 			{
 				title: "Capture a memory",
 				description: dedent(`
-					Open a session scoped to a user and record conversation turns. Spectron pulls out entities, attributes, and relations on every turn, so the memory graph fills in on its own.
+					Record a fact scoped to a user. Spectron pulls out entities, attributes, and relations server-side, so the memory graph fills in on its own.
 
 					~~~python
-					from surrealdb import SpectronTurnRole
-
-					session = client.sessions.create(scopes=["user/alex"])
-					session.turn(SpectronTurnRole.USER, "Hi, I'm Alex. I prefer dark mode.")
-					session.turn(SpectronTurnRole.ASSISTANT, "Got it Alex, noted.")
+					client.remember(
+					    "Hi, I'm Alex. I prefer dark mode.",
+					    infer="full",
+					    scope=["user/alex"],
+					)
 					~~~
 				`),
 			},
@@ -123,7 +123,7 @@ function buildIntegrationSteps(
 					Run one query that blends graph traversal, vector similarity, and structured filters, then get the most relevant memories back in a single call.
 
 					~~~python
-					results = client.query("What are the user's preferences?", k=10)
+					results = client.recall("What are the user's preferences?", k=10)
 
 					for hit in results.hits:
 					    print(hit.score, hit.text)
@@ -171,17 +171,13 @@ function buildIntegrationSteps(
 			{
 				title: "Capture a memory",
 				description: dedent(`
-					Open a session scoped to a user and record conversation turns. Spectron pulls out entities, attributes, and relations on every turn, so the memory graph fills in on its own.
+					Record a fact scoped to a user. Spectron pulls out entities, attributes, and relations server-side, so the memory graph fills in on its own.
 
 					~~~javascript
-					import { TurnRole } from "@surrealdb/spectron";
-
-					const session = await client.sessions.create({
-					    scopes: ["user/alex"],
+					await client.remember("Hi, I'm Alex. I prefer dark mode.", {
+					    infer: "full",
+					    scope: ["user/alex"],
 					});
-
-					await session.turn({ role: TurnRole.user, content: "Hi, I'm Alex. I prefer dark mode." });
-					await session.turn({ role: TurnRole.assistant, content: "Got it Alex, noted." });
 					~~~
 				`),
 			},
@@ -191,10 +187,7 @@ function buildIntegrationSteps(
 					Run one query that blends graph traversal, vector similarity, and structured filters, then get the most relevant memories back in a single call.
 
 					~~~javascript
-					const results = await client.query({
-					    query: "What are the user's preferences?",
-					    k: 10,
-					});
+					const hits = await client.recall("What are the user's preferences?", { k: 10 });
 					~~~
 				`),
 			},
@@ -217,29 +210,18 @@ function buildIntegrationSteps(
 				`),
 			},
 			{
-				title: "Open a session",
-				description: dedent(`
-					Create a session scoped to a user. The response includes an \`id\` you'll pass to subsequent calls when recording turns.
-
-					~~~bash
-					curl -X POST ${restRoot}/sessions \\
-					    -H "API-KEY: your-api-key" \\
-					    -H "Content-Type: application/json" \\
-					    -d '{"scopes":["user/alex"]}'
-					~~~
-				`),
-			},
-			{
 				title: "Capture a memory",
 				description: dedent(`
-					Record a conversation turn against the session you just created. Replace \`$SESSION_ID\` with the \`id\` returned from the previous call.
+					Record a fact against this context. Spectron extracts entities, attributes, and relations server-side, so the memory graph fills in on its own.
 
 					~~~bash
-					curl -X POST ${restRoot}/sessions/$SESSION_ID/turns \\
-					    -H "API-KEY: your-api-key" \\
+					curl -X POST ${restRoot}/facts \\
+					    -H "Authorization: Bearer your-api-key" \\
 					    -H "Content-Type: application/json" \\
-					    -d '{"role":"user","content":"Hi, I am Alex. I prefer dark mode."}'
+					    -d '{"text":"Hi, I am Alex. I prefer dark mode.","infer":"full","scope":["user/alex"]}'
 					~~~
+
+					To ingest a whole conversation at once, POST a \`turns\` array to \`${restRoot}/facts/batch\` instead.
 				`),
 			},
 			{
@@ -249,9 +231,9 @@ function buildIntegrationSteps(
 
 					~~~bash
 					curl -X POST ${restRoot}/query \\
-					    -H "API-KEY: your-api-key" \\
+					    -H "Authorization: Bearer your-api-key" \\
 					    -H "Content-Type: application/json" \\
-					    -d '{"query":"What are the user preferences?","k":10}'
+					    -d '{"query":"What are the user preferences?","limit":10,"scope":["user/alex"]}'
 					~~~
 				`),
 			},

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/claude-code.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/claude-code.tsx
@@ -10,10 +10,10 @@ export function buildClaudeCodeSteps(context: CloudContext): IntegrationStep[] {
 		{
 			title: "Install the MCP server",
 			description: dedent(`
-				Run the installer once. It prompts for your API key and merges Spectron into your Claude Code configuration for this context.
+				Install the Spectron plugin from the SurrealDB marketplace, running the command inside Claude Code. Provide your API key when prompted, or configure it manually as shown below.
 
 				~~~bash
-				npx install-mcp spectron --client claude-code --context ${context.id}
+				/plugin install spectron@surrealdb
 				~~~
 
 				<ApiKey />
@@ -38,6 +38,7 @@ export function buildClaudeCodeSteps(context: CloudContext): IntegrationStep[] {
 				{
 				  "mcpServers": {
 				    "spectron": {
+				      "type": "http",
 				      "url": "${mcpUrl}",
 				      "headers": {
 				        "Authorization": "Bearer your-api-key",

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/cli.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/cli.tsx
@@ -74,7 +74,7 @@ export function buildCliSteps(context: CloudContext): IntegrationStep[] {
 			description: dedent(`
 				Full command reference: remember, recall, context, reflect, consolidate, and the interactive terminal surfaces.
 
-				<Documentation href="https://surrealdb.com/docs/spectron/integrations/cli" />
+				<Documentation />
 			`),
 		},
 	];

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/cloudflare.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/cloudflare.tsx
@@ -4,80 +4,99 @@ import { getSpectronUrls } from "../helpers/spectron-urls";
 import type { IntegrationStep } from "./types";
 
 export function buildCloudflareSteps(context: CloudContext): IntegrationStep[] {
-	const { mcpUrl } = getSpectronUrls(context);
+	const { endpoint } = getSpectronUrls(context);
 
 	return [
 		{
-			title: "Install the packages",
+			title: "Install the package",
 			description: dedent(`
-				The Cloudflare Agents SDK ships a built-in MCP client. Add it alongside the AI SDK and the Workers AI provider.
+				Spectron runs inside a Cloudflare Worker through the \`@surrealdb/spectron\` SDK — no MCP client required. Add it to your Worker project.
 
 				~~~bash
-				npm install agents ai workers-ai-provider
+				npm install @surrealdb/spectron
 				~~~
 			`),
 		},
 		{
-			title: "Create API credentials",
+			title: "Create an API key",
 			description: dedent(`
-				The MCP client authenticates with an agent API key for this context. Create one here if you have not already.
+				The Worker authenticates with a scoped API key bound to your principal. Create one for this context, then store it as a secret with \`npx wrangler secret put SPECTRON_API_KEY\`.
 
 				<ApiKey />
 			`),
 		},
 		{
-			title: "Connect the MCP server",
+			title: "Configure the Worker",
 			description: dedent(`
-				From your Agent, connect Spectron as a streamable HTTP server. The endpoint is pre-filled from your selection; send your API key as a Bearer token and select this context with the X-Spectron-Context header.
+				Bind Workers AI and expose the Spectron connection details. The endpoint and context id are pre-filled from your selection; the API key comes from the secret you set.
+
+				~~~toml
+				[ai]
+				binding = "AI"
+
+				[vars]
+				SPECTRON_ENDPOINT = "${endpoint}"
+				SPECTRON_CONTEXT = "${context.id}"
+				~~~
 
 				~~~typescript
-				import { Agent } from "agents";
-
-				export class MemoryAgent extends Agent<Env> {
-				    async onStart() {
-				        await this.addMcpServer("spectron", "${mcpUrl}", {
-				            transport: {
-				                type: "streamable-http",
-				                headers: {
-				                    Authorization: "Bearer your-api-key",
-				                    "X-Spectron-Context": "${context.id}",
-				                },
-				            },
-				        });
-				    }
+				interface Env {
+				    AI: Ai;
+				    SPECTRON_ENDPOINT: string;
+				    SPECTRON_CONTEXT: string;
+				    SPECTRON_API_KEY: string;
 				}
 				~~~
 			`),
 		},
 		{
-			title: "Call the tools from your model",
+			title: "Recall, generate, and remember",
 			description: dedent(`
-				The connected server's memory and knowledge tools are exposed as AI SDK tools through \`this.mcp.getAITools()\`. Pass them to any model call so the agent can recall and remember.
+				Construct a client from the environment, recall relevant memory into the system prompt, run a Workers AI model, then persist the exchange with \`rememberMany\`.
 
 				~~~typescript
-				import { streamText } from "ai";
-				import { createWorkersAI } from "workers-ai-provider";
+				import { Spectron } from "@surrealdb/spectron";
 
-				async onRequest(request: Request) {
-				    const workersai = createWorkersAI({ binding: this.env.AI });
+				export default {
+				    async fetch(request: Request, env: Env): Promise<Response> {
+				        const { userId, message } = await request.json();
+				        const scope = [\`user/\${userId}\`];
 
-				    const result = await streamText({
-				        model: workersai("@cf/meta/llama-3.3-70b-instruct-fp8-fast"),
-				        prompt: "What are the user's preferences?",
-				        tools: this.mcp.getAITools(),
-				    });
+				        const spectron = new Spectron({
+				            endpoint: env.SPECTRON_ENDPOINT,
+				            context: env.SPECTRON_CONTEXT,
+				            apiKey: env.SPECTRON_API_KEY,
+				        });
 
-				    return result.toTextStreamResponse();
-				}
+				        const memory = await spectron.context(message, { scope, k: 8 });
+
+				        const result = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
+				            messages: [
+				                { role: "system", content: \`You are a helpful assistant.\\n\\n## Memory\\n\${memory}\` },
+				                { role: "user", content: message },
+				            ],
+				        });
+
+				        await spectron.rememberMany(
+				            [
+				                { role: "user", content: message },
+				                { role: "assistant", content: result.response },
+				            ],
+				            { scope },
+				        );
+
+				        return Response.json({ text: result.response });
+				    },
+				};
 				~~~
 			`),
 		},
 		{
 			title: "Explore Spectron",
 			description: dedent(`
-				See the full MCP server reference for the available memory and knowledge tools, scope headers, and authentication.
+				See the full Cloudflare Workers AI guide for streaming, tool-based recall, and background writes.
 
-				<Documentation href="https://surrealdb.com/docs/spectron/integrations/frameworks/cloudflare" />
+				<Documentation href="https://surrealdb.com/docs/spectron/integrations/ai-sdks/cloudflare-workers-ai" />
 			`),
 		},
 	];

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/codex.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/codex.tsx
@@ -8,13 +8,9 @@ export function buildCodexSteps(context: CloudContext): IntegrationStep[] {
 
 	return [
 		{
-			title: "Install the MCP server",
+			title: "Add the MCP server",
 			description: dedent(`
-				Run the installer once. It prompts for your API key and adds Spectron to Codex's MCP configuration for this context.
-
-				~~~bash
-				npx install-mcp spectron --client codex --context ${context.id}
-				~~~
+				Codex has no dedicated installer — add Spectron to Codex's MCP configuration manually, as shown in the next steps. Create your API key first.
 
 				<ApiKey />
 			`),

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/crew-ai.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/crew-ai.tsx
@@ -13,7 +13,7 @@ export function buildCrewAiSteps(context: CloudContext): IntegrationStep[] {
 				Give your CrewAI agents provenance-first memory backed by this context. Requires Python 3.10+ and CrewAI 1.5+.
 
 				~~~bash
-				pip install spectron-integration-crewai
+				pip install spectron-crew-ai
 				~~~
 
 				This pulls in CrewAI and the Spectron SDK (\`surrealdb[spectron]\`).

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/haskell.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/haskell.tsx
@@ -16,7 +16,7 @@ export function buildHaskellSteps(context: CloudContext): IntegrationStep[] {
 				source-repository-package
 				  type: git
 				  location: https://github.com/surrealdb/surrealdb.haskell
-				  subdir: surrealdb surrealdb-spectron
+				  subdir: surrealdb-spectron
 				~~~
 
 				Then add \`surrealdb-spectron\` to your component's \`build-depends\`.

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/hermes.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/hermes.tsx
@@ -13,10 +13,10 @@ export function buildHermesSteps(context: CloudContext): IntegrationStep[] {
 				The Spectron memory provider gives a Hermes Agent long-term memory: it recalls relevant memories before every turn, writes each completed turn back to Spectron, and consolidates memory when a session ends. Requires Python 3.10+.
 
 				~~~bash
-				pip install spectron-integration-hermes-agent
+				pip install spectron-hermes
 				~~~
 
-				This pulls in the Spectron SDK (\`surrealdb[spectron]\`) and registers the provider with Hermes.
+				This pulls in the SurrealDB SDK (\`surrealdb\` v3, which bundles Spectron) and registers the provider with Hermes through the \`hermes_agent.plugins\` entry point.
 			`),
 		},
 		{

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/langchain.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/langchain.tsx
@@ -13,7 +13,7 @@ export function buildLangChainSteps(context: CloudContext): IntegrationStep[] {
 				The official SurrealDB integration for the LangChain.js and LangGraph.js ecosystems wraps the \`@surrealdb/spectron\` client. Requires Node.js ≥ 22 or Bun ≥ 1.
 
 				~~~bash
-				bun add @surrealdb/langchain @surrealdb/langchain-core surrealdb
+				bun add @surrealdb/langchain @surrealdb/langgraph @surrealdb/spectron
 				~~~
 			`),
 		},

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/mcp.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/mcp.tsx
@@ -50,7 +50,7 @@ export function buildMcpSteps(context: CloudContext): IntegrationStep[] {
 			description: dedent(`
 				Read the MCP server reference for the available memory and knowledge tools, scope headers, and authentication.
 
-				<Documentation href="https://surrealdb.com/docs/spectron/integrations/mcp-server" />
+				<Documentation href="https://surrealdb.com/docs/spectron/integrations/mcp-server/install" />
 			`),
 		},
 	];

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/n8n.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/n8n.tsx
@@ -10,66 +10,51 @@ export function buildN8nSteps(context: CloudContext): IntegrationStep[] {
 		{
 			title: "Create an API key",
 			description: dedent(`
-				n8n workflows call Spectron over HTTPS with the same API-KEY header as the REST API. Create a key scoped to this context.
+				n8n workflows call Spectron over HTTPS with the same Bearer token as the REST API. Create a key scoped to this context.
 
 				<ApiKey />
 			`),
 		},
 		{
-			title: "Open a session (HTTP Request)",
+			title: "Recall memory (HTTP Request)",
 			description: dedent(`
-				Use an HTTP Request node against this context’s REST root. POST JSON with a scopes array; store the session id from the response for later nodes.
+				Before your LLM or Agent node, add an HTTP Request node that recalls ranked memory for the incoming message. Send the API key as a Bearer token.
 
-				~~~surrealql
-				-- POST ${restRoot}/sessions
+				~~~bash
+				# POST ${restRoot}/context
 
-				-- Headers:
-				--   API-KEY: {{ $env.SPECTRON_API_KEY }}
-				--   Content-Type: application/json
+				# Headers:
+				#   Authorization: Bearer {{ $env.SPECTRON_API_KEY }}
+				#   Content-Type: application/json
 
-				-- Body:
+				# Body:
 				{
-				  "scopes": ["user/{{ $json.userId }}"]
+				  "query": "{{ $json.chatInput }}",
+				  "scope": ["user/{{ $json.userId }}"],
+				  "k": 8
 				}
 				~~~
 			`),
 		},
 		{
-			title: "Record a turn",
+			title: "Store the turn (HTTP Request)",
 			description: dedent(`
-				POST user or assistant turns to /sessions/{id}/turns so Spectron can extract memory. Replace the session id with the value from the previous step.
+				After the agent responds, add another HTTP Request node that persists the exchange so Spectron can extract memory. Post a \`turns\` array to \`/facts/batch\`.
 
-				~~~surrealql
-				-- POST ${restRoot}/sessions/<session_id>/turns
+				~~~bash
+				# POST ${restRoot}/facts/batch
 
-				-- Headers:
-				--   API-KEY: {{ $env.SPECTRON_API_KEY }}
-				--   Content-Type: application/json
+				# Headers:
+				#   Authorization: Bearer {{ $env.SPECTRON_API_KEY }}
+				#   Content-Type: application/json
 
-				-- Body:
+				# Body:
 				{
-				  "role": "user",
-				  "content": "{{ $json.message }}"
-				}
-				~~~
-			`),
-		},
-		{
-			title: "Recall with hybrid search",
-			description: dedent(`
-				Add a query node to retrieve ranked memory for an incoming message before you call your LLM or downstream tools.
-
-				~~~surrealql
-				-- POST ${restRoot}/query
-
-				-- Headers:
-				--   API-KEY: {{ $env.SPECTRON_API_KEY }}
-				--   Content-Type: application/json
-
-				-- Body:
-				{
-				  "query": "{{ $json.userQuestion }}",
-				  "k": 10
+				  "turns": [
+				    { "role": "user", "content": "{{ $json.chatInput }}" },
+				    { "role": "assistant", "content": "{{ $json.output }}" }
+				  ],
+				  "scope": ["user/{{ $json.userId }}"]
 				}
 				~~~
 			`),
@@ -77,9 +62,9 @@ export function buildN8nSteps(context: CloudContext): IntegrationStep[] {
 		{
 			title: "Explore Spectron",
 			description: dedent(`
-				Read the REST surface reference for paths, payloads, and error handling.
+				Read the n8n integration guide for wiring these nodes into a chat workflow, plus the SurrealDB community node for direct database access.
 
-				<Documentation href="https://surrealdb.com/docs/spectron/integrations/surfaces/rest" />
+				<Documentation href="https://surrealdb.com/docs/spectron/integrations/automation/n8n" />
 			`),
 		},
 	];

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/openai-agents.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/openai-agents.tsx
@@ -13,10 +13,7 @@ export function buildOpenAiAgentsSteps(context: CloudContext): IntegrationStep[]
 				Give agents built with the OpenAI Agents SDK a durable, shared memory backed by this context.
 
 				~~~bash
-				pip install spectron-openai-agents
-
-				# During the Spectron preview, install the SDK extra too:
-				pip install "spectron-openai-agents[spectron]"
+				pip install spectron-openai-agents-sdk
 				~~~
 			`),
 		},
@@ -48,7 +45,7 @@ export function buildOpenAiAgentsSteps(context: CloudContext): IntegrationStep[]
 
 				~~~python
 				from agents import Agent, Runner
-				from spectron_openai_agents import get_spectron_tools
+				from spectron_openai_agents_sdk import get_spectron_tools
 
 				agent = Agent(
 				    name="assistant",

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/strands.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/strands.tsx
@@ -13,7 +13,7 @@ export function buildStrandsSteps(context: CloudContext): IntegrationStep[] {
 				Expose this context's memory operations as tools for any Strands agent. Requires Python 3.10+.
 
 				~~~bash
-				pip install spectron-strands
+				pip install spectron-strands-agents
 				~~~
 
 				This pulls in \`strands-agents\` and \`surrealdb\` (which provides the Spectron client).
@@ -42,7 +42,7 @@ export function buildStrandsSteps(context: CloudContext): IntegrationStep[] {
 		{
 			title: "Attach the tools",
 			description: dedent(`
-				With the environment set, \`spectron_tools()\` builds the client for you and returns seven memory tools — \`remember\`, \`recall\`, \`context\`, \`reflect\`, \`forget\`, \`upload\`, and \`inspect\`.
+				With the environment set, \`spectron_tools()\` builds the client for you and returns seven memory tools — \`spectron_remember\`, \`spectron_recall\`, \`spectron_context\`, \`spectron_reflect\`, \`spectron_forget\`, \`spectron_upload\`, and \`spectron_inspect\`.
 
 				~~~python
 				from strands import Agent
@@ -54,7 +54,7 @@ export function buildStrandsSteps(context: CloudContext): IntegrationStep[] {
 				print(agent("What is the value of the Meditech Solutions contract?"))
 				~~~
 
-				Narrow the set with \`include=[...]\` or \`exclude=[...]\`.
+				Narrow the set with \`include=[...]\` or \`exclude=[...]\`, using the bare names (\`remember\`, \`recall\`, …) as filter values.
 			`),
 		},
 		{

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/swift.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/swift.tsx
@@ -51,7 +51,7 @@ export function buildSwiftSteps(context: CloudContext): IntegrationStep[] {
 				Run one query that blends graph traversal, vector similarity, and structured filters, then get the most relevant memories back in a single call.
 
 				~~~swift
-				let hits = try await memory.recall("What are the user's preferences?", k: 10)
+				let hits = try await memory.query("What are the user's preferences?", k: 10)
 				~~~
 			`),
 		},

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/tanstack.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/tanstack.tsx
@@ -4,71 +4,73 @@ import { getSpectronUrls } from "../helpers/spectron-urls";
 import type { IntegrationStep } from "./types";
 
 export function buildTanStackSteps(context: CloudContext): IntegrationStep[] {
-	const { mcpUrl } = getSpectronUrls(context);
+	const { endpoint } = getSpectronUrls(context);
 
 	return [
 		{
 			title: "Install the packages",
 			description: dedent(`
-				TanStack AI ships a first-party MCP host client. Add it alongside the core package, the MCP SDK peer dependency, and your chosen provider adapter.
+				TanStack AI works with Spectron through the \`@surrealdb/spectron\` SDK directly — there is no dedicated MCP adapter. Add it alongside the core package and your provider adapter.
 
 				~~~bash
-				npm install @tanstack/ai @tanstack/ai-mcp @modelcontextprotocol/sdk @tanstack/ai-openai
+				npm install @surrealdb/spectron @tanstack/ai @tanstack/ai-openai
 				~~~
 			`),
 		},
 		{
-			title: "Create API credentials",
+			title: "Create an API key",
 			description: dedent(`
-				The MCP client authenticates with an agent API key for this context. Create one here if you have not already.
+				The SDK authenticates with a scoped API key bound to your principal. Create one for this context.
 
 				<ApiKey />
 			`),
 		},
 		{
-			title: "Connect the MCP server",
+			title: "Configure the client",
 			description: dedent(`
-				In a server route (MCP tool execution is server-side only), create a client for Spectron over the streamable HTTP transport. The endpoint is pre-filled from your selection. Send your API key as a Bearer token, and select this context with the X-Spectron-Context header.
+				In a server handler (Spectron runs server-side, wherever you call \`chat()\`), construct a client for this context. The endpoint and context id are pre-filled from your selection.
 
 				~~~typescript
-				import { createMCPClient } from "@tanstack/ai-mcp";
+				import { Spectron } from "@surrealdb/spectron";
+				import { chat, toServerSentEventsResponse } from "@tanstack/ai";
+				import { openaiText } from "@tanstack/ai-openai";
 
-				const spectron = await createMCPClient({
-				    transport: {
-				        type: "http",
-				        url: "${mcpUrl}",
-				        headers: {
-				            Authorization: "Bearer your-api-key",
-				            "X-Spectron-Context": "${context.id}",
-				        },
-				    },
+				const spectron = new Spectron({
+				    endpoint: "${endpoint}",
+				    context: "${context.id}",
+				    apiKey: "your-api-key",
 				});
 				~~~
 			`),
 		},
 		{
-			title: "Pass the tools to chat",
+			title: "Recall memory into chat",
 			description: dedent(`
-				Hand the client to \`chat\` under \`mcp.clients\`. TanStack AI discovers Spectron's memory and knowledge tools, exposes them to the model, and closes the client when the run finishes.
+				Recall relevant memory with \`spectron.context\`, inject it into the system prompt for \`chat()\`, and stream the response back.
 
 				~~~typescript
-				import { chat } from "@tanstack/ai";
-				import { openaiText } from "@tanstack/ai-openai";
+				const memory = await spectron.context(message, { scope, k: 8 });
 
 				const stream = chat({
 				    adapter: openaiText("gpt-4o"),
-				    messages,
-				    mcp: { clients: [spectron] },
+				    messages: [
+				        { role: "system", content: \`You are a helpful assistant.\\n\\n## Memory\\n\${memory}\` },
+				        { role: "user", content: message },
+				    ],
 				});
+
+				return toServerSentEventsResponse(stream);
 				~~~
+
+				To persist the exchange, collect the reply with \`streamToText\` and call \`spectron.rememberMany([...], { scope })\`. Prefer the model to decide when to recall? Expose it as a \`toolDefinition\` whose \`.server()\` handler calls \`spectron.context\`, and pass it via \`tools: [recall]\`.
 			`),
 		},
 		{
 			title: "Explore Spectron",
 			description: dedent(`
-				See the full MCP server reference for the available memory and knowledge tools, scope headers, and authentication.
+				See the full TanStack AI guide for tool-based recall, streaming, and scope handling.
 
-				<Documentation href="https://surrealdb.com/docs/spectron/integrations/frameworks/tanstack-ai" />
+				<Documentation href="https://surrealdb.com/docs/spectron/integrations/ai-sdks/tanstack-ai" />
 			`),
 		},
 	];

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/vercel-ai.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/vercel-ai.tsx
@@ -13,7 +13,7 @@ export function buildVercelAiSteps(context: CloudContext): IntegrationStep[] {
 				Add the Spectron integration for the Vercel AI SDK, alongside \`ai\` (v7) and the Spectron client. Keep using your own model provider.
 
 				~~~bash
-				npm i @surrealdb/vercel-ai ai @surrealdb/spectron
+				npm i @surrealdb/spectron-vercel-ai ai @surrealdb/spectron
 				# plus your model provider, e.g.
 				npm i @ai-sdk/openai
 				~~~
@@ -33,7 +33,7 @@ export function buildVercelAiSteps(context: CloudContext): IntegrationStep[] {
 				Construct a Spectron instance pointed at this context. The endpoint and context id are pre-filled from your selection, and \`defaultScopes\` binds reads and writes to a region of memory.
 
 				~~~typescript
-				import { createSpectron, Spectron } from "@surrealdb/vercel-ai";
+				import { createSpectron, Spectron } from "@surrealdb/spectron-vercel-ai";
 
 				const spectron = createSpectron({
 				    client: new Spectron({

--- a/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/zapier.tsx
+++ b/src/screens/surrealist/pages/Context/views/IntegrationView/integrations/zapier.tsx
@@ -52,7 +52,7 @@ export function buildZapierSteps(context: CloudContext): IntegrationStep[] {
 			description: dedent(`
 				See the full MCP server reference for the available memory and knowledge tools, scope headers, and authentication.
 
-				<Documentation href="https://surrealdb.com/docs/spectron/integrations/mcp-server" />
+				<Documentation href="https://surrealdb.com/docs/spectron/integrations/mcp-server/install" />
 			`),
 		},
 	];


### PR DESCRIPTION
## Summary

Deep-verified every Spectron **context integration card** against the official documentation at [surrealdb.com/docs/spectron/integrations](https://surrealdb.com/docs/spectron/integrations) (source of truth) and corrected the cards whose steps diverged. Each documented integration was cross-checked for package names, install commands, imports, API signatures, env vars, config paths, auth headers, and documentation links.

Verified via `tsc --noEmit` (0 errors) and `biome check` (clean). Browser preview wasn't run because these cards only render inside an authenticated Cloud context backed by a live Spectron instance; the changes are content-only markdown within the step builders.

## Integrations updated

**High-impact / full rewrites**
- **Cloudflare** — card described an MCP-client approach (`addMcpServer`, `getAITools`) that the docs do **not** use. Rewritten to the documented `@surrealdb/spectron` SDK flow (`spectron.context()` → `env.AI.run()` → `spectron.rememberMany()`), correct install (`npm install @surrealdb/spectron`), and fixed doc link (`/frameworks/cloudflare` → `/ai-sdks/cloudflare-workers-ai`).
- **TanStack AI** — same class of error. Rewritten to the SDK-direct flow (`spectron.context()` + `chat()` + `toServerSentEventsResponse`), correct install, fixed doc link (`/frameworks/tanstack-ai` → `/ai-sdks/tanstack-ai`).
- **n8n** — invented a `/sessions` + `/sessions/{id}/turns` REST API that does not exist, used the wrong `API-KEY` header, and mislabelled HTTP pseudo-code as `surrealql`. Rewritten to the documented HTTP Request flow (`/context` recall + `/facts/batch` store, `Authorization: Bearer`), and doc link pointed at `/automation/n8n`.
- **REST API card** — `API-KEY` header → `Authorization: Bearer` (×3), and the fabricated `/sessions` flow replaced with the documented `POST /facts` (`text`/`infer`/`scope`) and `POST /query` (`query`/`limit`/`scope`).
- **Python & JavaScript SDKs** — capture step used a non-existent `sessions.create()`/`session.turn()` API (with `SpectronTurnRole`/`TurnRole`); replaced with the documented `client.remember(...)`. Recall changed from `client.query(...)` to `client.recall(...)`.

**Package / name / link corrections**
- **Claude Code** — replaced the fabricated `npx install-mcp spectron --client claude-code --context …` with the documented marketplace command `/plugin install spectron@surrealdb`; added the missing `"type": "http"` to the config block.
- **Codex** — dropped the fabricated `npx install-mcp` installer (Codex has no npx installer per docs); step now points to manual TOML config.
- **CrewAI** — `spectron-integration-crewai` → `spectron-crew-ai`.
- **OpenAI Agents** — `spectron-openai-agents` → `spectron-openai-agents-sdk` (package + import), removed the unverified `[spectron]` extra line.
- **Strands** — `spectron-strands` → `spectron-strands-agents`; tool names corrected to the `spectron_`-prefixed forms actually returned (bare names are filter values).
- **Vercel AI** — `@surrealdb/vercel-ai` → `@surrealdb/spectron-vercel-ai` (install + import).
- **LangChain** — install line `@surrealdb/langchain-core surrealdb` → `@surrealdb/langgraph @surrealdb/spectron`.
- **Hermes** — `spectron-integration-hermes-agent` → `spectron-hermes`; dependency description corrected (`surrealdb` v3 bundles Spectron via the `hermes_agent.plugins` entry point, not `surrealdb[spectron]`).
- **Swift** — retrieval method `memory.recall(...)` → `memory.query(...)`.
- **Haskell** — cabal `subdir: surrealdb surrealdb-spectron` → `subdir: surrealdb-spectron`.
- **Zapier & generic MCP** — doc link `/mcp-server` (404s to marketing page) → `/mcp-server/install`.
- **CLI** — broken `/integrations/cli` link (no such doc page) dropped to the general Spectron docs fallback.

## Confident these are correct (verified against docs, no changes needed)

- **Go, Kotlin, Elixir, Dart** SDKs — install, imports, constructors, `remember`/`recall` all match the docs.
- **VS Code** — config schema (`servers` key + `type: http`), paths, and verify steps match byte-for-byte.
- **Cursor, Zed** — config schema, paths, auth, and doc links correct (see validation notes below for two cosmetic items).
- **Google ADK, Eve, Pydantic AI, OpenClaw** — packages, imports, class names, env vars, config, and tool lists all match the docs. (Pydantic AI's `namespace=` parameter is correct per docs.)

## Needs additional validation

These weren't changed (or only partially), because the docs are silent, self-inconsistent, or appear to lag the product — worth confirming with the Spectron team:

- **CLI card (whole card)** — there is **no CLI documentation page**; docs describe Spectron as a single binary with the MCP server built in. The `spectron login/remember/recall/repl/tui` commands and the `install.sh` URL are unverifiable. `consolidate` is listed but isn't a documented verb, and `forget` is absent. Only the broken doc link was fixed.
- **OpenAI Agents env vars** — the doc uses `SPECTRON_NAMESPACE` + `SPECTRON_DATABASE` (namespace/database-scoped) and does **not** list `SPECTRON_CONTEXT`. The card still pre-fills `SPECTRON_CONTEXT` with the cloud context id; the correct mapping for a Cloud context needs a product decision (left as-is).
- **Codex TOML** — docs show `bearer_token_env_var` + inline `http_headers`, whereas the card uses `bearer_token` + `experimental_use_rmcp_client` + a separate `[…http_headers]` table. Both look like valid Codex options; left as-is pending confirmation.
- **REST scope shape** — the `surfaces/rest` and `reference/rest-api` pages disagree on the scope key/shape (`scope` vs `scopes`, flat vs nested array). Used `scope` (flat) per `surfaces/rest`.
- **Swift `remember(_, role:)`** — the `role:` overload isn't attested in the Swift doc (which shows `triples:`/`infer:`); only the recall method was corrected.
- **Kotlin `InferMode` import** — `com.surrealdb.kotlin.spectron.model.InferMode` subpackage path wasn't surfaced by the doc (the `InferMode.FULL` usage itself is confirmed).
- **Cursor/Zed cosmetics** — doc says Cursor verify path is *Settings → Features → MCP*; Zed's documented schema omits the `source: "custom"` field the card includes (real Zed requires it). Left as-is.